### PR TITLE
Rename consts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+- Rename constants. Add prefix Serega for come classes. Previously in applications that use same class names this classes have to be defined with two colons "::".
+  - Serega::Attribute -> Serega::SeregaAttribute
+  - Serega::Convert -> Serega::SeregaConvert
+  - Serega::ConvertItem -> Serega::SeregaConvertItem
+  - Serega::Error -> Serega::SeregaError
+  - Serega::Helpers -> Serega::SeregaHelpers
+  - Serega::Map -> Serega::SeregaMap
+  - Serega::Utils -> Serega::SeregaUtils
+  - Serega::Validations -> Serega::SeregaValidations
+
+
 ## [0.1.5] - 2022-08-27
 
 - Added config option `config[:preloads][:auto_hide_attributes_with_preload]` to `preloads` plugin. By default it is `false`.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
     end
   ```
 
-## Plugins
+## SeregaPlugins
 
 ### Plugin :preloads
   Allows to find `preloads` for current serializer. It merges **only** preloads specified in currently serialized attributes, skipping preloads of not serialized attributes.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
     end
   ```
 
-## SeregaPlugins
+## Plugins
 
 ### Plugin :preloads
   Allows to find `preloads` for current serializer. It merges **only** preloads specified in currently serialized attributes, skipping preloads of not serialized attributes.

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@
 
 ## Errors
 
-  - `Serega::Error` is a base error raised by this gem.
+  - `Serega::SeregaError` is a base error raised by this gem.
   - `Serega::AttributeNotExist` error is raised when validating attributes in `:only, :except, :with` modifiers with `:validate_modifiers` plugin
 
 ## Development

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -51,19 +51,19 @@ class Serega
       attribute_keys: %i[key value serializer many hide const],
       serialize_keys: %i[context many],
       max_cached_map_per_serializer_count: 50,
-      to_json: ->(data) { Utils::ToJSON.call(data) }
+      to_json: ->(data) { SeregaUtils::ToJSON.call(data) }
     }
   )
 
-  check_attribute_params_class = Class.new(Validations::CheckAttributeParams)
+  check_attribute_params_class = Class.new(SeregaValidations::CheckAttributeParams)
   check_attribute_params_class.serializer_class = self
   const_set(:CheckAttributeParams, check_attribute_params_class)
 
-  check_initiate_params_class = Class.new(Validations::CheckInitiateParams)
+  check_initiate_params_class = Class.new(SeregaValidations::CheckInitiateParams)
   check_initiate_params_class.serializer_class = self
   const_set(:CheckInitiateParams, check_initiate_params_class)
 
-  check_serialize_params_class = Class.new(Validations::CheckSerializeParams)
+  check_serialize_params_class = Class.new(SeregaValidations::CheckSerializeParams)
   check_serialize_params_class.serializer_class = self
   const_set(:CheckSerializeParams, check_serialize_params_class)
 
@@ -125,7 +125,7 @@ class Serega
     def plugin(name, **opts)
       raise Error, "This plugin is already loaded" if plugin_used?(name)
 
-      plugin = Plugins.find_plugin(name)
+      plugin = SeregaPlugins.find_plugin(name)
 
       # We split loading of plugin to three parts - before_load, load, after_load:
       #
@@ -278,7 +278,7 @@ class Serega
     #
     def as_json(object, opts = FROZEN_EMPTY_HASH)
       hash = to_h(object, opts)
-      Utils::AsJSON.call(hash, to_json: self.class.config[:to_json])
+      SeregaUtils::AsJSON.call(hash, to_json: self.class.config[:to_json])
     end
 
     private
@@ -289,9 +289,9 @@ class Serega
 
     def prepare_modifiers(opts)
       {
-        only: Utils::ToHash.call(opts[:only]),
-        except: Utils::ToHash.call(opts[:except]),
-        with: Utils::ToHash.call(opts[:with])
+        only: SeregaUtils::ToHash.call(opts[:only]),
+        except: SeregaUtils::ToHash.call(opts[:except]),
+        with: SeregaUtils::ToHash.call(opts[:with])
       }
     end
   end

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -44,7 +44,7 @@ require_relative "serega/map"
 require_relative "serega/plugins"
 
 class Serega
-  @config = Config.new(
+  @config = SeregaConfig.new(
     {
       plugins: [],
       initiate_keys: %i[only with except],
@@ -69,18 +69,18 @@ class Serega
 
   # Core serializer class methods
   module ClassMethods
-    # @return [Config] current serializer config
+    # @return [SeregaConfig] current serializer config
     attr_reader :config
 
     private def inherited(subclass)
-      config_class = Class.new(self::Config)
+      config_class = Class.new(self::SeregaConfig)
       config_class.serializer_class = subclass
-      subclass.const_set(:Config, config_class)
-      subclass.instance_variable_set(:@config, subclass::Config.new(config.opts))
+      subclass.const_set(:SeregaConfig, config_class)
+      subclass.instance_variable_set(:@config, subclass::SeregaConfig.new(config.opts))
 
-      attribute_class = Class.new(self::Attribute)
+      attribute_class = Class.new(self::SeregaAttribute)
       attribute_class.serializer_class = subclass
-      subclass.const_set(:Attribute, attribute_class)
+      subclass.const_set(:SeregaAttribute, attribute_class)
 
       map_class = Class.new(self::Map)
       map_class.serializer_class = subclass
@@ -175,10 +175,10 @@ class Serega
     # @param opts [Hash] Options to serialize attribute
     # @param block [Proc] Custom block to find attribute value. Accepts object and context.
     #
-    # @return [Serega::Attribute] Added attribute
+    # @return [Serega::SeregaAttribute] Added attribute
     #
     def attribute(name, **opts, &block)
-      attribute = self::Attribute.new(name: name, opts: opts, block: block)
+      attribute = self::SeregaAttribute.new(name: name, opts: opts, block: block)
       attributes[attribute.name] = attribute
     end
 
@@ -190,7 +190,7 @@ class Serega
     # @param opts [Hash] Options for attribute serialization
     # @param block [Proc] Custom block to find attribute value. Accepts object and context.
     #
-    # @return [Serega::Attribute] Added attribute
+    # @return [Serega::SeregaAttribute] Added attribute
     #
     def relation(name, serializer:, **opts, &block)
       attribute(name, serializer: serializer, **opts, &block)

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -82,17 +82,17 @@ class Serega
       attribute_class.serializer_class = subclass
       subclass.const_set(:SeregaAttribute, attribute_class)
 
-      map_class = Class.new(self::Map)
+      map_class = Class.new(self::SeregaMap)
       map_class.serializer_class = subclass
-      subclass.const_set(:Map, map_class)
+      subclass.const_set(:SeregaMap, map_class)
 
-      convert_class = Class.new(self::Convert)
+      convert_class = Class.new(self::SeregaConvert)
       convert_class.serializer_class = subclass
-      subclass.const_set(:Convert, convert_class)
+      subclass.const_set(:SeregaConvert, convert_class)
 
-      convert_item_class = Class.new(self::ConvertItem)
+      convert_item_class = Class.new(self::SeregaConvertItem)
       convert_item_class.serializer_class = subclass
-      subclass.const_set(:ConvertItem, convert_item_class)
+      subclass.const_set(:SeregaConvertItem, convert_item_class)
 
       check_attribute_params_class = Class.new(self::CheckAttributeParams)
       check_attribute_params_class.serializer_class = subclass
@@ -247,7 +247,7 @@ class Serega
       self.class::CheckSerializeParams.call(opts)
       opts[:context] ||= {}
 
-      self.class::Convert.call(object, **opts, map: map)
+      self.class::SeregaConvert.call(object, **opts, map: map)
     end
 
     # @see #call
@@ -284,7 +284,7 @@ class Serega
     private
 
     def map
-      @map ||= self.class::Map.call(opts)
+      @map ||= self.class::SeregaMap.call(opts)
     end
 
     def prepare_modifiers(opts)

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -5,7 +5,7 @@ require_relative "serega/version"
 # Parent class for your serializers
 class Serega
   # A generic exception Serega uses.
-  class Error < StandardError; end
+  class SeregaError < StandardError; end
 
   # @return [Hash] frozen hash
   FROZEN_EMPTY_HASH = {}.freeze
@@ -123,7 +123,7 @@ class Serega
     # @return [class<Module>] Loaded plugin module
     #
     def plugin(name, **opts)
-      raise Error, "This plugin is already loaded" if plugin_used?(name)
+      raise SeregaError, "This plugin is already loaded" if plugin_used?(name)
 
       plugin = SeregaPlugins.find_plugin(name)
 

--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -36,7 +36,7 @@ class Serega
         self.class.serializer_class::CheckAttributeParams.new(name, opts, block).validate
 
         @name = name.to_sym
-        @opts = Utils::EnumDeepDup.call(opts)
+        @opts = SeregaUtils::EnumDeepDup.call(opts)
         @block = block
       end
 
@@ -125,7 +125,7 @@ class Serega
       end
     end
 
-    extend Serega::Helpers::SerializerClassHelper
+    extend Serega::SeregaHelpers::SerializerClassHelper
     include AttributeInstanceMethods
   end
 end

--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -4,7 +4,7 @@ class Serega
   #
   # Stores Attribute data
   #
-  class Attribute
+  class SeregaAttribute
     #
     # Stores Attribute instance methods
     #

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -20,7 +20,7 @@ class Serega
       # @param opts [Hash] Initial config options
       #
       def initialize(opts = {})
-        @opts = Utils::EnumDeepDup.call(opts)
+        @opts = SeregaUtils::EnumDeepDup.call(opts)
       end
 
       #
@@ -43,6 +43,6 @@ class Serega
     end
 
     include ConfigInstanceMethods
-    extend Serega::Helpers::SerializerClassHelper
+    extend Serega::SeregaHelpers::SerializerClassHelper
   end
 end

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -6,8 +6,8 @@ class Serega
   #
   # Core class that stores serializer configuration
   #
-  class Config
-    module ConfigInstanceMethods
+  class SeregaConfig
+    module SeregaConfigInstanceMethods
       extend Forwardable
 
       # @return [Hash] Current config data
@@ -42,7 +42,7 @@ class Serega
       def_delegators :opts, :[], :[]=, :fetch, :keys, :has_key?
     end
 
-    include ConfigInstanceMethods
+    include SeregaConfigInstanceMethods
     extend Serega::SeregaHelpers::SerializerClassHelper
   end
 end

--- a/lib/serega/convert.rb
+++ b/lib/serega/convert.rb
@@ -38,7 +38,7 @@ class Serega
       end
     end
 
-    extend Serega::Helpers::SerializerClassHelper
+    extend Serega::SeregaHelpers::SerializerClassHelper
     extend ConvertClassMethods
     include ConvertInstanceMethods
   end

--- a/lib/serega/convert.rb
+++ b/lib/serega/convert.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
-  class Convert
-    module ConvertClassMethods
+  class SeregaConvert
+    module SeregaConvertClassMethods
       def call(object, **opts)
         new(object, **opts).to_h
       end
     end
 
-    module ConvertInstanceMethods
+    module SeregaConvertInstanceMethods
       attr_reader :object, :opts
 
       def initialize(object, **opts)
@@ -27,7 +27,7 @@ class Serega
       end
 
       def one(object)
-        self.class.serializer_class::ConvertItem.call(object, opts[:context], opts[:map])
+        self.class.serializer_class::SeregaConvertItem.call(object, opts[:context], opts[:map])
       end
 
       def many?
@@ -39,7 +39,7 @@ class Serega
     end
 
     extend Serega::SeregaHelpers::SerializerClassHelper
-    extend ConvertClassMethods
-    include ConvertInstanceMethods
+    extend SeregaConvertClassMethods
+    include SeregaConvertInstanceMethods
   end
 end

--- a/lib/serega/convert_item.rb
+++ b/lib/serega/convert_item.rb
@@ -31,7 +31,7 @@ class Serega
       end
     end
 
-    extend Serega::Helpers::SerializerClassHelper
+    extend Serega::SeregaHelpers::SerializerClassHelper
     extend ConvertItemClassMethods
   end
 end

--- a/lib/serega/convert_item.rb
+++ b/lib/serega/convert_item.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serega
-  class ConvertItem
-    module ConvertItemClassMethods
+  class SeregaConvertItem
+    module SeregaConvertItemClassMethods
       def call(object, context, map)
         return unless object
 
@@ -32,6 +32,6 @@ class Serega
     end
 
     extend Serega::SeregaHelpers::SerializerClassHelper
-    extend ConvertItemClassMethods
+    extend SeregaConvertItemClassMethods
   end
 end

--- a/lib/serega/helpers/serializer_class_helper.rb
+++ b/lib/serega/helpers/serializer_class_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Helpers
+  module SeregaHelpers
     # Stores link to current serializer class
     module SerializerClassHelper
       # @return [Class<Serega>] Serializer class that current class is namespaced under.

--- a/lib/serega/map.rb
+++ b/lib/serega/map.rb
@@ -44,6 +44,6 @@ class Serega
     end
 
     extend ClassMethods
-    extend Serega::Helpers::SerializerClassHelper
+    extend Serega::SeregaHelpers::SerializerClassHelper
   end
 end

--- a/lib/serega/map.rb
+++ b/lib/serega/map.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  class Map
+  class SeregaMap
     module ClassMethods
       def call(opts)
         @cache ||= {}

--- a/lib/serega/plugins.rb
+++ b/lib/serega/plugins.rb
@@ -2,7 +2,7 @@
 
 class Serega
   # Module in which all Serega plugins should be stored
-  module Plugins
+  module SeregaPlugins
     @plugins = {}
 
     class << self
@@ -10,7 +10,7 @@ class Serega
       # Registers given plugin to be able to load it using symbol name.
       #
       # @example Register plugin
-      #   Serega::Plugins.register_plugin(:plugin_name, PluginModule)
+      #   Serega::SeregaPlugins.register_plugin(:plugin_name, PluginModule)
       def register_plugin(name, mod)
         @plugins[name] = mod
       end
@@ -23,10 +23,10 @@ class Serega
       # @raise [Error] Raises Error when plugin was not found
       #
       # @example Find plugin when providing name
-      #   Serega::Plugins.find_plugin(:presenter) # => Serega::Plugins::Presenter
+      #   Serega::SeregaPlugins.find_plugin(:presenter) # => Serega::SeregaPlugins::Presenter
       #
       # @example Find plugin when providing plugin itself
-      #   Serega::Plugins.find_plugin(Presenter) # => Presenter
+      #   Serega::SeregaPlugins.find_plugin(Presenter) # => Presenter
       #
       # @return [Class<Module>] Plugin core module
       #

--- a/lib/serega/plugins.rb
+++ b/lib/serega/plugins.rb
@@ -20,7 +20,7 @@ class Serega
       #
       # @param name [Symbol, Module] plugin name or plugin itself
       #
-      # @raise [Error] Raises Error when plugin was not found
+      # @raise [SeregaError] Raises SeregaError when plugin was not found
       #
       # @example Find plugin when providing name
       #   Serega::SeregaPlugins.find_plugin(:presenter) # => Serega::SeregaPlugins::Presenter
@@ -36,7 +36,7 @@ class Serega
 
         require_plugin(name)
 
-        @plugins[name] || raise(Error, "Plugin '#{name}' did not register itself correctly")
+        @plugins[name] || raise(SeregaError, "Plugin '#{name}' did not register itself correctly")
       end
 
       private
@@ -44,7 +44,7 @@ class Serega
       def require_plugin(name)
         require "serega/plugins/#{name}/#{name}"
       rescue LoadError
-        raise Error, "Plugin '#{name}' does not exist"
+        raise SeregaError, "Plugin '#{name}' does not exist"
       end
     end
   end

--- a/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
+++ b/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     #
     # Plugin that checks used plugins and loads correct Preloader for selected response type
-    # @see Serega::Plugins::JsonApiActiverecordPreloader
-    # @see Serega::Plugins::SimpleApiActiverecordPreloader
+    # @see Serega::SeregaPlugins::JsonApiActiverecordPreloader
+    # @see Serega::SeregaPlugins::SimpleApiActiverecordPreloader
     #
     module ActiverecordPreloads
       # @return [Symbol] plugin name

--- a/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
+++ b/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module ActiverecordPreloads
       class Preloader
         module ClassMethods

--- a/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
+++ b/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
@@ -7,7 +7,7 @@ class Serega
         module ClassMethods
           def preload(object, preloads)
             preload_handler = handlers.find { |handler| handler.fit?(object) }
-            raise Error, "Can't preload #{preloads.inspect} to #{object.inspect}" unless preload_handler
+            raise SeregaError, "Can't preload #{preloads.inspect} to #{object.inspect}" unless preload_handler
 
             preload_handler.preload(object, preloads)
           end

--- a/lib/serega/plugins/context_metadata/context_metadata.rb
+++ b/lib/serega/plugins/context_metadata/context_metadata.rb
@@ -14,7 +14,7 @@ class Serega
       end
 
       def self.load_plugin(serializer_class, **_opts)
-        serializer_class::Convert.include(ConvertInstanceMethods)
+        serializer_class::SeregaConvert.include(SeregaConvertInstanceMethods)
         serializer_class::CheckSerializeParams.extend(CheckSerializeParamsClassMethods)
       end
 
@@ -34,7 +34,7 @@ class Serega
         end
       end
 
-      module ConvertInstanceMethods
+      module SeregaConvertInstanceMethods
         def to_h
           super.tap do |hash|
             add_context_metadata(hash)

--- a/lib/serega/plugins/context_metadata/context_metadata.rb
+++ b/lib/serega/plugins/context_metadata/context_metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module ContextMetadata
       DEFAULT_CONTEXT_METADATA_KEY = :meta
 
@@ -30,7 +30,7 @@ class Serega
           super
 
           meta_key = serializer_class.config[:context_metadata][:key]
-          Validations::Utils::CheckOptIsHash.call(opts, meta_key)
+          SeregaValidations::SeregaUtils::CheckOptIsHash.call(opts, meta_key)
         end
       end
 

--- a/lib/serega/plugins/formatters/formatters.rb
+++ b/lib/serega/plugins/formatters/formatters.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Formatters
       def self.plugin_name
         :formatters

--- a/lib/serega/plugins/formatters/formatters.rb
+++ b/lib/serega/plugins/formatters/formatters.rb
@@ -8,7 +8,7 @@ class Serega
       end
 
       def self.load_plugin(serializer_class, **_opts)
-        serializer_class::Attribute.include(AttributeInstanceMethods)
+        serializer_class::SeregaAttribute.include(AttributeInstanceMethods)
       end
 
       def self.after_load_plugin(serializer_class, **_opts)

--- a/lib/serega/plugins/hide_nil/hide_nil.rb
+++ b/lib/serega/plugins/hide_nil/hide_nil.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     #
     # Plugin adds `:hide_nil` option to attributes to delete them from final result
     # if value is nil

--- a/lib/serega/plugins/hide_nil/hide_nil.rb
+++ b/lib/serega/plugins/hide_nil/hide_nil.rb
@@ -21,7 +21,7 @@ class Serega
       # @return [void]
       #
       def self.load_plugin(serializer_class, **_opts)
-        serializer_class::Attribute.include(AttributeMethods)
+        serializer_class::SeregaAttribute.include(AttributeMethods)
         serializer_class::CheckAttributeParams.include(CheckAttributeParamsInstanceMethods)
         serializer_class::ConvertItem.extend(ConvertItemClassMethods)
       end

--- a/lib/serega/plugins/hide_nil/hide_nil.rb
+++ b/lib/serega/plugins/hide_nil/hide_nil.rb
@@ -23,7 +23,7 @@ class Serega
       def self.load_plugin(serializer_class, **_opts)
         serializer_class::SeregaAttribute.include(AttributeMethods)
         serializer_class::CheckAttributeParams.include(CheckAttributeParamsInstanceMethods)
-        serializer_class::ConvertItem.extend(ConvertItemClassMethods)
+        serializer_class::SeregaConvertItem.extend(SeregaConvertItemClassMethods)
       end
 
       def self.after_load_plugin(serializer_class, **opts)
@@ -66,7 +66,7 @@ class Serega
         end
       end
 
-      module ConvertItemClassMethods
+      module SeregaConvertItemClassMethods
         private
 
         def attach_value(value, *args)

--- a/lib/serega/plugins/hide_nil/hide_nil.rb
+++ b/lib/serega/plugins/hide_nil/hide_nil.rb
@@ -52,7 +52,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Serega::Error] Error that option has invalid value
+        # @raise [Serega::SeregaError] SeregaError that option has invalid value
         #
         # @return [void]
         #
@@ -62,7 +62,7 @@ class Serega
           value = opts[:hide_nil]
           return if (value == true) || (value == false)
 
-          raise Error, "Invalid option :hide_nil => #{value.inspect}. Must have a boolean value"
+          raise SeregaError, "Invalid option :hide_nil => #{value.inspect}. Must have a boolean value"
         end
       end
 

--- a/lib/serega/plugins/metadata/meta_attribute.rb
+++ b/lib/serega/plugins/metadata/meta_attribute.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       #
       # Stores Attribute data
@@ -36,8 +36,8 @@ class Serega
             check(path, opts, block)
 
             @name = path.join(".").to_sym
-            @path = Utils::EnumDeepDup.call(path)
-            @opts = Utils::EnumDeepDup.call(opts)
+            @path = SeregaUtils::EnumDeepDup.call(path)
+            @opts = SeregaUtils::EnumDeepDup.call(opts)
             @block = block
           end
 
@@ -66,7 +66,7 @@ class Serega
           end
         end
 
-        extend Serega::Helpers::SerializerClassHelper
+        extend Serega::SeregaHelpers::SerializerClassHelper
         include InstanceMethods
       end
     end

--- a/lib/serega/plugins/metadata/metadata.rb
+++ b/lib/serega/plugins/metadata/metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       def self.plugin_name
         :metadata

--- a/lib/serega/plugins/metadata/metadata.rb
+++ b/lib/serega/plugins/metadata/metadata.rb
@@ -13,7 +13,7 @@ class Serega
 
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
-        serializer_class::Convert.include(ConvertInstanceMethods)
+        serializer_class::SeregaConvert.include(SeregaConvertInstanceMethods)
 
         require_relative "./meta_attribute"
         require_relative "./validations/check_block"
@@ -79,7 +79,7 @@ class Serega
         end
       end
 
-      module ConvertInstanceMethods
+      module SeregaConvertInstanceMethods
         def to_h
           hash = super
           add_metadata(hash)

--- a/lib/serega/plugins/metadata/validations/check_block.rb
+++ b/lib/serega/plugins/metadata/validations/check_block.rb
@@ -25,17 +25,17 @@ class Serega
             #
             # @param block [Proc] Block that returns serialized meta attribute value
             #
-            # @raise [Error] Error that block has invalid arguments
+            # @raise [SeregaError] SeregaError that block has invalid arguments
             #
             # @return [void]
             #
             def call(block)
-              raise Error, "Block must be provided when defining meta attribute" unless block
+              raise SeregaError, "Block must be provided when defining meta attribute" unless block
 
               params = block.parameters
               return if (params.count <= 2) && params.all? { |par| ALLOWED_PARAM_TYPES.include?(par[0]) }
 
-              raise Error, "Block can have maximum 2 regular parameters (no **keyword or *array args)"
+              raise SeregaError, "Block can have maximum 2 regular parameters (no **keyword or *array args)"
             end
           end
         end

--- a/lib/serega/plugins/metadata/validations/check_block.rb
+++ b/lib/serega/plugins/metadata/validations/check_block.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       class MetaAttribute
         class CheckBlock

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       class MetaAttribute
         class CheckOptHideEmpty

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
@@ -11,7 +11,7 @@ class Serega
             #
             # @param opts [Hash] Attribute options
             #
-            # @raise [Error] Error that option has invalid value
+            # @raise [SeregaError] SeregaError that option has invalid value
             #
             # @return [void]
             #
@@ -21,7 +21,7 @@ class Serega
               value = opts[:hide_empty]
               return if value == true
 
-              raise Error, "Invalid option :hide_empty => #{value.inspect}. Must be true"
+              raise SeregaError, "Invalid option :hide_empty => #{value.inspect}. Must be true"
             end
           end
         end

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
@@ -11,7 +11,7 @@ class Serega
             #
             # @param opts [Hash] Attribute options
             #
-            # @raise [Error] Error that option has invalid value
+            # @raise [SeregaError] SeregaError that option has invalid value
             #
             # @return [void]
             #
@@ -21,7 +21,7 @@ class Serega
               value = opts[:hide_nil]
               return if value == true
 
-              raise Error, "Invalid option :hide_nil => #{value.inspect}. Must be true"
+              raise SeregaError, "Invalid option :hide_nil => #{value.inspect}. Must be true"
             end
           end
         end

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       class MetaAttribute
         class CheckOptHideNil

--- a/lib/serega/plugins/metadata/validations/check_opts.rb
+++ b/lib/serega/plugins/metadata/validations/check_opts.rb
@@ -13,7 +13,7 @@ class Serega
             # @param opts [Hash] Attribute options
             # @param attribute_keys [Array<Symbol>] Allowed options keys
             #
-            # @raise [Error] when attribute has invalid options
+            # @raise [SeregaError] when attribute has invalid options
             #
             # @return [void]
             #
@@ -21,7 +21,7 @@ class Serega
               opts.each_key do |key|
                 next if attribute_keys.include?(key.to_sym)
 
-                raise Error, "Invalid option #{key.inspect}. Allowed options are: #{attribute_keys.map(&:inspect).join(", ")}"
+                raise SeregaError, "Invalid option #{key.inspect}. Allowed options are: #{attribute_keys.map(&:inspect).join(", ")}"
               end
 
               check_each_opt(opts)

--- a/lib/serega/plugins/metadata/validations/check_opts.rb
+++ b/lib/serega/plugins/metadata/validations/check_opts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       class MetaAttribute
         class CheckOpts

--- a/lib/serega/plugins/metadata/validations/check_path.rb
+++ b/lib/serega/plugins/metadata/validations/check_path.rb
@@ -18,7 +18,7 @@ class Serega
             #
             # @param path [Array<String, Symbol>] Metadata attribute path names
             #
-            # @raise [Error] when metadata attribute name has invalid format
+            # @raise [SeregaError] when metadata attribute name has invalid format
             # @return [void]
             #
             def call(path)
@@ -39,7 +39,7 @@ class Serega
 
               return if valid
 
-              raise Error, message(name)
+              raise SeregaError, message(name)
             end
 
             def message(name)

--- a/lib/serega/plugins/metadata/validations/check_path.rb
+++ b/lib/serega/plugins/metadata/validations/check_path.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Metadata
       class MetaAttribute
         class CheckPath

--- a/lib/serega/plugins/preloads/lib/enum_deep_freeze.rb
+++ b/lib/serega/plugins/preloads/lib/enum_deep_freeze.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Preloads
       # Freezes nested enumerable data
       class EnumDeepFreeze

--- a/lib/serega/plugins/preloads/lib/format_user_preloads.rb
+++ b/lib/serega/plugins/preloads/lib/format_user_preloads.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Preloads
       # Transforms user provided preloads to hash
       class FormatUserPreloads

--- a/lib/serega/plugins/preloads/lib/main_preload_path.rb
+++ b/lib/serega/plugins/preloads/lib/main_preload_path.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Preloads
       class MainPreloadPath
         module ClassMethods

--- a/lib/serega/plugins/preloads/lib/preloads_constructor.rb
+++ b/lib/serega/plugins/preloads/lib/preloads_constructor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Preloads
       #
       # Finds relations to preload for provided serializer
@@ -29,7 +29,7 @@ class Serega
               next unless current_preloads
 
               has_nested = nested_map.any?
-              current_preloads = Utils::EnumDeepDup.call(current_preloads) if has_nested
+              current_preloads = SeregaUtils::EnumDeepDup.call(current_preloads) if has_nested
               append_current(preloads, current_preloads)
               next unless has_nested
 

--- a/lib/serega/plugins/preloads/preloads.rb
+++ b/lib/serega/plugins/preloads/preloads.rb
@@ -21,7 +21,7 @@ class Serega
       #
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.include(InstanceMethods)
-        serializer_class::Attribute.include(AttributeMethods)
+        serializer_class::SeregaAttribute.include(AttributeMethods)
 
         serializer_class::CheckAttributeParams.include(CheckAttributeParamsInstanceMethods)
 

--- a/lib/serega/plugins/preloads/preloads.rb
+++ b/lib/serega/plugins/preloads/preloads.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     #
     # Plugin adds `.preloads` method to find relations that must be preloaded
     #

--- a/lib/serega/plugins/preloads/validations/check_opt_preload_path.rb
+++ b/lib/serega/plugins/preloads/validations/check_opt_preload_path.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Preloads
       class CheckOptPreloadPath
         class << self

--- a/lib/serega/plugins/preloads/validations/check_opt_preload_path.rb
+++ b/lib/serega/plugins/preloads/validations/check_opt_preload_path.rb
@@ -9,13 +9,13 @@ class Serega
             return unless opts.key?(:preload_path)
 
             value = opts[:preload_path]
-            raise Error, "Invalid option :preload_path => #{value.inspect}. Can be provided only when :preload option provided" unless opts[:preload]
-            raise Error, "Invalid option :preload_path => #{value.inspect}. Can be provided only when :serializer option provided" unless opts[:serializer]
+            raise SeregaError, "Invalid option :preload_path => #{value.inspect}. Can be provided only when :preload option provided" unless opts[:preload]
+            raise SeregaError, "Invalid option :preload_path => #{value.inspect}. Can be provided only when :serializer option provided" unless opts[:serializer]
 
             path = Array(value).map!(&:to_sym)
             preloads = FormatUserPreloads.call(opts[:preload])
             allowed_paths = paths(preloads)
-            raise Error, "Invalid option :preload_path => #{value.inspect}. Can be one of #{allowed_paths.inspect[1..-2]}" unless allowed_paths.include?(path)
+            raise SeregaError, "Invalid option :preload_path => #{value.inspect}. Can be one of #{allowed_paths.inspect[1..-2]}" unless allowed_paths.include?(path)
           end
 
           private

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -35,7 +35,7 @@ class Serega
       #
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
-        serializer_class::ConvertItem.extend(ConvertItemClassMethods)
+        serializer_class::SeregaConvertItem.extend(SeregaConvertItemClassMethods)
       end
 
       #
@@ -94,8 +94,8 @@ class Serega
         end
       end
 
-      # Includes methods to override ConvertItem class
-      module ConvertItemClassMethods
+      # Includes methods to override SeregaConvertItem class
+      module SeregaConvertItemClassMethods
         #
         # Replaces serialized object with Presenter.new(object)
         #

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -4,7 +4,7 @@ require "delegate"
 require "forwardable"
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     #
     # Plugin Presenter adds possibility to use declare Presenter for your objects inside serializer
     #
@@ -69,7 +69,7 @@ class Serega
           end
         end
 
-        extend Helpers::SerializerClassHelper
+        extend SeregaHelpers::SerializerClassHelper
         extend Forwardable
         include InstanceMethods
       end
@@ -85,7 +85,7 @@ class Serega
         end
 
         # Overrides {Serega::ClassMethods#attribute} method, additionally adds method
-        # to Presenter to not hit {Serega::Plugins::Presenter::Presenter#method_missing}
+        # to Presenter to not hit {Serega::SeregaPlugins::Presenter::Presenter#method_missing}
         # @see Serega::ClassMethods#attribute
         def attribute(_name, **_opts, &_block)
           super.tap do |attribute|

--- a/lib/serega/plugins/root/root.rb
+++ b/lib/serega/plugins/root/root.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module Root
       # @return [Symbol] Default response root key
       ROOT_DEFAULT = :data

--- a/lib/serega/plugins/root/root.rb
+++ b/lib/serega/plugins/root/root.rb
@@ -12,7 +12,7 @@ class Serega
 
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
-        serializer_class::Convert.include(ConvertInstanceMethods)
+        serializer_class::SeregaConvert.include(SeregaConvertInstanceMethods)
       end
 
       def self.after_load_plugin(serializer_class, **opts)
@@ -41,7 +41,7 @@ class Serega
         end
       end
 
-      module ConvertInstanceMethods
+      module SeregaConvertInstanceMethods
         def to_h
           hash = super
           root = build_root(opts)

--- a/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
+++ b/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module StringModifiers
       class ParseStringModifiers
         COMMA = ","

--- a/lib/serega/plugins/string_modifiers/string_modifiers.rb
+++ b/lib/serega/plugins/string_modifiers/string_modifiers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module StringModifiers
       def self.plugin_name
         :string_modifiers

--- a/lib/serega/plugins/validate_modifiers/validate.rb
+++ b/lib/serega/plugins/validate_modifiers/validate.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  class AttributeNotExist < Error
+  class AttributeNotExist < SeregaError
   end
 
   module SeregaPlugins

--- a/lib/serega/plugins/validate_modifiers/validate.rb
+++ b/lib/serega/plugins/validate_modifiers/validate.rb
@@ -4,7 +4,7 @@ class Serega
   class AttributeNotExist < Error
   end
 
-  module Plugins
+  module SeregaPlugins
     module ValidateModifiers
       class Validate
         class << self

--- a/lib/serega/plugins/validate_modifiers/validate_modifiers.rb
+++ b/lib/serega/plugins/validate_modifiers/validate_modifiers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Plugins
+  module SeregaPlugins
     module ValidateModifiers
       def self.plugin_name
         :validate_modifiers

--- a/lib/serega/utils/as_json.rb
+++ b/lib/serega/utils/as_json.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Utils
+  module SeregaUtils
     class AsJSON
       DOUBLE_QUOTE = '"'
 

--- a/lib/serega/utils/enum_deep_dup.rb
+++ b/lib/serega/utils/enum_deep_dup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Utils
+  module SeregaUtils
     # Duplicates nested hashes and arrays
     class EnumDeepDup
       DUP = {

--- a/lib/serega/utils/to_hash.rb
+++ b/lib/serega/utils/to_hash.rb
@@ -11,7 +11,7 @@ class Serega
           when NilClass, FalseClass then nil_to_hash(value)
           when String then string_to_hash(value)
           when Symbol then symbol_to_hash(value)
-          else raise Error, "Cant convert #{value.class} class object to hash"
+          else raise SeregaError, "Cant convert #{value.class} class object to hash"
           end
         end
 

--- a/lib/serega/utils/to_hash.rb
+++ b/lib/serega/utils/to_hash.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Utils
+  module SeregaUtils
     class ToHash
       module ClassMethods
         def call(value)

--- a/lib/serega/utils/to_json.rb
+++ b/lib/serega/utils/to_json.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Utils
+  module SeregaUtils
     class ToJSON
       class << self
         def call(data)

--- a/lib/serega/validations/attribute/check_block.rb
+++ b/lib/serega/validations/attribute/check_block.rb
@@ -22,7 +22,7 @@ class Serega
           # @param opts [Proc] Attribute opts, we will check :value option
           # @param block [Proc] Block that returns serialized attribute value
           #
-          # @raise [Error] Error that block has invalid arguments
+          # @raise [SeregaError] SeregaError that block has invalid arguments
           #
           # @return [void]
           #
@@ -38,7 +38,7 @@ class Serega
             params = block.parameters
             return if (params.count <= 2) && params.all? { |par| par[0] == :opt }
 
-            raise Error, block_error
+            raise SeregaError, block_error
           end
 
           def block_error

--- a/lib/serega/validations/attribute/check_block.rb
+++ b/lib/serega/validations/attribute/check_block.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckBlock
         class << self

--- a/lib/serega/validations/attribute/check_name.rb
+++ b/lib/serega/validations/attribute/check_name.rb
@@ -17,7 +17,7 @@ class Serega
           #
           # @param name [String, Symbol] Attribute name
           #
-          # @raise [Error] when name has invalid format
+          # @raise [SeregaError] when name has invalid format
           # @return [void]
           #
           def call(name)
@@ -32,7 +32,7 @@ class Serega
 
             return if valid
 
-            raise Error, message(name)
+            raise SeregaError, message(name)
           end
 
           private

--- a/lib/serega/validations/attribute/check_name.rb
+++ b/lib/serega/validations/attribute/check_name.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckName
         FORMAT_ONE_CHAR = /\A[a-zA-Z0-9]\z/

--- a/lib/serega/validations/attribute/check_opt_const.rb
+++ b/lib/serega/validations/attribute/check_opt_const.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptConst
         #

--- a/lib/serega/validations/attribute/check_opt_const.rb
+++ b/lib/serega/validations/attribute/check_opt_const.rb
@@ -9,7 +9,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Error] Attribute validation error
+        # @raise [SeregaError] Attribute validation error
         #
         # @return [void]
         #
@@ -23,9 +23,9 @@ class Serega
           private
 
           def check_usage_with_other_params(opts, block)
-            raise Error, "Option :const can not be used together with option :key" if opts.key?(:key)
-            raise Error, "Option :const can not be used together with option :value" if opts.key?(:value)
-            raise Error, "Option :const can not be used together with block" if block
+            raise SeregaError, "Option :const can not be used together with option :key" if opts.key?(:key)
+            raise SeregaError, "Option :const can not be used together with option :value" if opts.key?(:value)
+            raise SeregaError, "Option :const can not be used together with block" if block
           end
         end
       end

--- a/lib/serega/validations/attribute/check_opt_hide.rb
+++ b/lib/serega/validations/attribute/check_opt_hide.rb
@@ -9,7 +9,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Error] Error that option has invalid value
+        # @raise [SeregaError] SeregaError that option has invalid value
         #
         # @return [void]
         #

--- a/lib/serega/validations/attribute/check_opt_hide.rb
+++ b/lib/serega/validations/attribute/check_opt_hide.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptHide
         #
@@ -14,7 +14,7 @@ class Serega
         # @return [void]
         #
         def self.call(opts)
-          Utils::CheckOptIsBool.call(opts, :hide)
+          SeregaUtils::CheckOptIsBool.call(opts, :hide)
         end
       end
     end

--- a/lib/serega/validations/attribute/check_opt_key.rb
+++ b/lib/serega/validations/attribute/check_opt_key.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptKey
         #
@@ -18,7 +18,7 @@ class Serega
             return unless opts.key?(:key)
 
             check_usage_with_other_params(opts, block)
-            Utils::CheckOptIsStringOrSymbol.call(opts, :key)
+            SeregaUtils::CheckOptIsStringOrSymbol.call(opts, :key)
           end
 
           private

--- a/lib/serega/validations/attribute/check_opt_key.rb
+++ b/lib/serega/validations/attribute/check_opt_key.rb
@@ -9,7 +9,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Error] Error that option has invalid value
+        # @raise [SeregaError] SeregaError that option has invalid value
         #
         # @return [void]
         #
@@ -24,9 +24,9 @@ class Serega
           private
 
           def check_usage_with_other_params(opts, block)
-            raise Error, "Option :key can not be used together with option :const" if opts.key?(:const)
-            raise Error, "Option :key can not be used together with option :value" if opts.key?(:value)
-            raise Error, "Option :key can not be used together with block" if block
+            raise SeregaError, "Option :key can not be used together with option :const" if opts.key?(:const)
+            raise SeregaError, "Option :key can not be used together with option :value" if opts.key?(:value)
+            raise SeregaError, "Option :key can not be used together with block" if block
           end
         end
       end

--- a/lib/serega/validations/attribute/check_opt_many.rb
+++ b/lib/serega/validations/attribute/check_opt_many.rb
@@ -9,7 +9,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Error] Error that option has invalid value
+        # @raise [SeregaError] SeregaError that option has invalid value
         #
         # @return [void]
         #

--- a/lib/serega/validations/attribute/check_opt_many.rb
+++ b/lib/serega/validations/attribute/check_opt_many.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptMany
         #
@@ -14,7 +14,7 @@ class Serega
         # @return [void]
         #
         def self.call(opts)
-          Utils::CheckOptIsBool.call(opts, :many)
+          SeregaUtils::CheckOptIsBool.call(opts, :many)
         end
       end
     end

--- a/lib/serega/validations/attribute/check_opt_serializer.rb
+++ b/lib/serega/validations/attribute/check_opt_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptSerializer
         class << self

--- a/lib/serega/validations/attribute/check_opt_serializer.rb
+++ b/lib/serega/validations/attribute/check_opt_serializer.rb
@@ -10,7 +10,7 @@ class Serega
           #
           # @param opts [Hash] Attribute options
           #
-          # @raise [Error] Error that option has invalid value
+          # @raise [SeregaError] SeregaError that option has invalid value
           #
           # @return [void]
           #
@@ -20,7 +20,7 @@ class Serega
             value = opts[:serializer]
             return if valid_serializer?(value)
 
-            raise Error, "Invalid option :serializer => #{value.inspect}." \
+            raise SeregaError, "Invalid option :serializer => #{value.inspect}." \
               " Can be a Serega subclass, a String or a Proc without arguments"
           end
 

--- a/lib/serega/validations/attribute/check_opt_value.rb
+++ b/lib/serega/validations/attribute/check_opt_value.rb
@@ -9,7 +9,7 @@ class Serega
         #
         # @param opts [Hash] Attribute options
         #
-        # @raise [Error] Error that option has invalid value
+        # @raise [SeregaError] SeregaError that option has invalid value
         #
         # @return [void]
         #
@@ -24,13 +24,13 @@ class Serega
           private
 
           def check_usage_with_other_params(opts, block)
-            raise Error, "Option :value can not be used together with option :key" if opts.key?(:key)
-            raise Error, "Option :value can not be used together with option :const" if opts.key?(:const)
-            raise Error, "Option :value can not be used together with block" if block
+            raise SeregaError, "Option :value can not be used together with option :key" if opts.key?(:key)
+            raise SeregaError, "Option :value can not be used together with option :const" if opts.key?(:const)
+            raise SeregaError, "Option :value can not be used together with block" if block
           end
 
           def check_proc(value)
-            raise Error, value_error unless value.is_a?(Proc)
+            raise SeregaError, value_error unless value.is_a?(Proc)
 
             params = value.parameters
 
@@ -40,7 +40,7 @@ class Serega
               return
             end
 
-            raise Error, value_error
+            raise SeregaError, value_error
           end
 
           def value_error

--- a/lib/serega/validations/attribute/check_opt_value.rb
+++ b/lib/serega/validations/attribute/check_opt_value.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     module Attribute
       class CheckOptValue
         #

--- a/lib/serega/validations/check_attribute_params.rb
+++ b/lib/serega/validations/check_attribute_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     class CheckAttributeParams
       module InstanceMethods
         attr_reader :name, :opts, :block
@@ -25,7 +25,7 @@ class Serega
         end
 
         def check_opts
-          Utils::CheckAllowedKeys.call(opts, allowed_opts_keys)
+          SeregaUtils::CheckAllowedKeys.call(opts, allowed_opts_keys)
 
           Attribute::CheckOptConst.call(opts, block)
           Attribute::CheckOptHide.call(opts)
@@ -45,7 +45,7 @@ class Serega
       end
 
       include InstanceMethods
-      extend Serega::Helpers::SerializerClassHelper
+      extend Serega::SeregaHelpers::SerializerClassHelper
     end
   end
 end

--- a/lib/serega/validations/check_initiate_params.rb
+++ b/lib/serega/validations/check_initiate_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     class CheckInitiateParams
       module ClassMethods
         def call(opts)
@@ -11,7 +11,7 @@ class Serega
         private
 
         def check_opts(opts)
-          Utils::CheckAllowedKeys.call(opts, allowed_opts_keys)
+          SeregaUtils::CheckAllowedKeys.call(opts, allowed_opts_keys)
         end
 
         def allowed_opts_keys
@@ -20,7 +20,7 @@ class Serega
       end
 
       extend ClassMethods
-      extend Serega::Helpers::SerializerClassHelper
+      extend Serega::SeregaHelpers::SerializerClassHelper
     end
   end
 end

--- a/lib/serega/validations/check_serialize_params.rb
+++ b/lib/serega/validations/check_serialize_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
+  module SeregaValidations
     class CheckSerializeParams
       module ClassMethods
         def call(opts)
@@ -11,10 +11,10 @@ class Serega
         private
 
         def check_opts(opts)
-          Utils::CheckAllowedKeys.call(opts, allowed_opts_keys)
+          SeregaUtils::CheckAllowedKeys.call(opts, allowed_opts_keys)
 
-          Utils::CheckOptIsHash.call(opts, :context)
-          Utils::CheckOptIsBool.call(opts, :many)
+          SeregaUtils::CheckOptIsHash.call(opts, :context)
+          SeregaUtils::CheckOptIsBool.call(opts, :many)
         end
 
         def allowed_opts_keys
@@ -23,7 +23,7 @@ class Serega
       end
 
       extend ClassMethods
-      extend Serega::Helpers::SerializerClassHelper
+      extend Serega::SeregaHelpers::SerializerClassHelper
     end
   end
 end

--- a/lib/serega/validations/utils/check_allowed_keys.rb
+++ b/lib/serega/validations/utils/check_allowed_keys.rb
@@ -8,7 +8,7 @@ class Serega
           opts.each_key do |key|
             next if allowed_keys.include?(key)
 
-            raise Error, "Invalid option #{key.inspect}. Allowed options are: #{allowed_keys.map(&:inspect).join(", ")}"
+            raise SeregaError, "Invalid option #{key.inspect}. Allowed options are: #{allowed_keys.map(&:inspect).join(", ")}"
           end
         end
       end

--- a/lib/serega/validations/utils/check_allowed_keys.rb
+++ b/lib/serega/validations/utils/check_allowed_keys.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
-    module Utils
+  module SeregaValidations
+    module SeregaUtils
       class CheckAllowedKeys
         def self.call(opts, allowed_keys)
           opts.each_key do |key|

--- a/lib/serega/validations/utils/check_opt_is_bool.rb
+++ b/lib/serega/validations/utils/check_opt_is_bool.rb
@@ -10,7 +10,7 @@ class Serega
           value = opts[key]
           return if value.equal?(true) || value.equal?(false)
 
-          raise Error, "Invalid option #{key.inspect} => #{value.inspect}. Must have a boolean value"
+          raise SeregaError, "Invalid option #{key.inspect} => #{value.inspect}. Must have a boolean value"
         end
       end
     end

--- a/lib/serega/validations/utils/check_opt_is_bool.rb
+++ b/lib/serega/validations/utils/check_opt_is_bool.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
-    module Utils
+  module SeregaValidations
+    module SeregaUtils
       class CheckOptIsBool
         def self.call(opts, key)
           return unless opts.key?(key)

--- a/lib/serega/validations/utils/check_opt_is_hash.rb
+++ b/lib/serega/validations/utils/check_opt_is_hash.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
-    module Utils
+  module SeregaValidations
+    module SeregaUtils
       class CheckOptIsHash
         def self.call(opts, key)
           return unless opts.key?(key)

--- a/lib/serega/validations/utils/check_opt_is_hash.rb
+++ b/lib/serega/validations/utils/check_opt_is_hash.rb
@@ -10,7 +10,7 @@ class Serega
           value = opts[key]
           return if value.is_a?(Hash)
 
-          raise Error, "Invalid option #{key.inspect} => #{value.inspect}. Must have a Hash value"
+          raise SeregaError, "Invalid option #{key.inspect} => #{value.inspect}. Must have a Hash value"
         end
       end
     end

--- a/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
+++ b/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Serega
-  module Validations
-    module Utils
+  module SeregaValidations
+    module SeregaUtils
       class CheckOptIsStringOrSymbol
         def self.call(opts, key)
           return unless opts.key?(key)

--- a/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
+++ b/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
@@ -10,7 +10,7 @@ class Serega
           value = opts[key]
           return if value.is_a?(String) || value.is_a?(Symbol)
 
-          raise Error, "Invalid option #{key.inspect} => #{value.inspect}. Must be a String or a Symbol"
+          raise SeregaError, "Invalid option #{key.inspect} => #{value.inspect}. Must be a String or a Symbol"
         end
       end
     end

--- a/sig/serega.rbs
+++ b/sig/serega.rbs
@@ -4,6 +4,6 @@
 module Serega
   VERSION: String
 
-  class Error < StandardError
+  class SeregaError < StandardSeregaError
   end
 end

--- a/spec/serega/attribute_spec.rb
+++ b/spec/serega/attribute_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Attribute do
+RSpec.describe Serega::SeregaAttribute do
   let(:serializer_class) { Class.new(Serega) }
-  let(:attribute_class) { serializer_class::Attribute }
+  let(:attribute_class) { serializer_class::SeregaAttribute }
 
   describe ".initialize" do
     it "validates provided params" do

--- a/spec/serega/config_spec.rb
+++ b/spec/serega/config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Config do
+RSpec.describe Serega::SeregaConfig do
   let(:serializer_class) { Class.new(Serega) }
   let(:config) { serializer_class.config }
 

--- a/spec/serega/convert_spec.rb
+++ b/spec/serega/convert_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Convert do
+RSpec.describe Serega::SeregaConvert do
   subject(:result) { user_serializer.new(**modifiers).to_h(user, context: context) }
 
   let(:user_serializer) do

--- a/spec/serega/map_spec.rb
+++ b/spec/serega/map_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Map do
+RSpec.describe Serega::SeregaMap do
   let(:base_class) { Class.new(Serega) }
-  let(:described_class) { a::Map }
+  let(:described_class) { a::SeregaMap }
 
   let(:a) do
     ser = Class.new(base_class)

--- a/spec/serega/plugins/activerecord_preloads/activerecord_preloads_spec.rb
+++ b/spec/serega/plugins/activerecord_preloads/activerecord_preloads_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :activerecord_preloads
 
-RSpec.describe Serega::Plugins::ActiverecordPreloads do
+RSpec.describe Serega::SeregaPlugins::ActiverecordPreloads do
   it "loads preloads plugin" do
     new_class = Class.new(Serega)
     new_class.plugin :activerecord_preloads
@@ -25,7 +25,7 @@ RSpec.describe Serega::Plugins::ActiverecordPreloads do
       serializer = serializer_class.new
       allow(serializer).to receive(:preloads).and_return(preloads)
 
-      allow(Serega::Plugins::ActiverecordPreloads::Preloader)
+      allow(Serega::SeregaPlugins::ActiverecordPreloads::Preloader)
         .to receive(:preload)
         .with(object, preloads)
         .and_return("OBJ_WITH_PRELOADS")

--- a/spec/serega/plugins/activerecord_preloads/lib/preloader_spec.rb
+++ b/spec/serega/plugins/activerecord_preloads/lib/preloader_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe Serega::SeregaPlugins::ActiverecordPreloads do
 
         object = nil
         expect { described_class.preload(object, {}) }
-          .to raise_error Serega::Error, "Can't preload #{preloads.inspect} to #{object.inspect}"
+          .to raise_error Serega::SeregaError, "Can't preload #{preloads.inspect} to #{object.inspect}"
 
         object = []
         expect { described_class.preload(object, {}) }
-          .to raise_error Serega::Error, "Can't preload #{preloads.inspect} to #{object.inspect}"
+          .to raise_error Serega::SeregaError, "Can't preload #{preloads.inspect} to #{object.inspect}"
 
         object = 123
         expect { described_class.preload(object, {}) }
-          .to raise_error Serega::Error, "Can't preload #{preloads.inspect} to #{object.inspect}"
+          .to raise_error Serega::SeregaError, "Can't preload #{preloads.inspect} to #{object.inspect}"
 
         object = [AR::User.create!, AR::Comment.create!]
         expect { described_class.preload(object, {}) }
-          .to raise_error Serega::Error, "Can't preload #{preloads.inspect} to #{object.inspect}"
+          .to raise_error Serega::SeregaError, "Can't preload #{preloads.inspect} to #{object.inspect}"
       end
 
       it "preloads data to activerecord object" do

--- a/spec/serega/plugins/activerecord_preloads/lib/preloader_spec.rb
+++ b/spec/serega/plugins/activerecord_preloads/lib/preloader_spec.rb
@@ -4,9 +4,9 @@ require "support/activerecord"
 
 load_plugin_code :activerecord_preloads
 
-RSpec.describe Serega::Plugins::ActiverecordPreloads do
+RSpec.describe Serega::SeregaPlugins::ActiverecordPreloads do
   describe described_class::Preloader do
-    let(:plugin) { Serega::Plugins::ActiverecordPreloads }
+    let(:plugin) { Serega::SeregaPlugins::ActiverecordPreloads }
 
     describe ".handlers" do
       it "returns array of handlers" do

--- a/spec/serega/plugins/context_metadata/context_metadata_spec.rb
+++ b/spec/serega/plugins/context_metadata/context_metadata_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :context_metadata
 
-RSpec.describe Serega::Plugins::ContextMetadata do
+RSpec.describe Serega::SeregaPlugins::ContextMetadata do
   describe "loading" do
     it "loads additional :root plugin if was not loaded before" do
       serializer = Class.new(Serega) { plugin :context_metadata }

--- a/spec/serega/plugins/context_metadata/context_metadata_spec.rb
+++ b/spec/serega/plugins/context_metadata/context_metadata_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe Serega::SeregaPlugins::ContextMetadata do
     it "raises error when default context meta key is not a Hash" do
       ser = Class.new(Serega) { plugin :context_metadata }
       expect { ser.new.to_h(nil, meta: []) }
-        .to raise_error Serega::Error, "Invalid option :meta => []. Must have a Hash value"
+        .to raise_error Serega::SeregaError, "Invalid option :meta => []. Must have a Hash value"
     end
 
     it "raises error when configured context meta key is not a Hash" do
       ser = Class.new(Serega) { plugin :context_metadata, context_metadata_key: :foo }
       expect { ser.new.to_h(nil, foo: []) }
-        .to raise_error Serega::Error, "Invalid option :foo => []. Must have a Hash value"
+        .to raise_error Serega::SeregaError, "Invalid option :foo => []. Must have a Hash value"
     end
   end
 

--- a/spec/serega/plugins/formatters/formatters_spec.rb
+++ b/spec/serega/plugins/formatters/formatters_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :formatters
 
-RSpec.describe Serega::Plugins::Formatters do
+RSpec.describe Serega::SeregaPlugins::Formatters do
   describe "loading" do
     it "adds empty :formatters config option" do
       serializer = Class.new(Serega) { plugin :formatters }

--- a/spec/serega/plugins/hide_nil/hide_nil_spec.rb
+++ b/spec/serega/plugins/hide_nil/hide_nil_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Serega::SeregaPlugins::HideNil do
 
       it "raises error when not boolean value provided" do
         expect { serializer_class.attribute :foo, hide_nil: 1 }
-          .to raise_error Serega::Error, "Invalid option :hide_nil => 1. Must have a boolean value"
+          .to raise_error Serega::SeregaError, "Invalid option :hide_nil => 1. Must have a boolean value"
       end
     end
   end

--- a/spec/serega/plugins/hide_nil/hide_nil_spec.rb
+++ b/spec/serega/plugins/hide_nil/hide_nil_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :hide_nil
 
-RSpec.describe Serega::Plugins::HideNil do
+RSpec.describe Serega::SeregaPlugins::HideNil do
   let(:serializer_class) { Class.new(Serega) }
 
   it "adds allowed attribute options" do

--- a/spec/serega/plugins/metadata/metadata_spec.rb
+++ b/spec/serega/plugins/metadata/metadata_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :metadata
 
-RSpec.describe Serega::Plugins::Metadata do
+RSpec.describe Serega::SeregaPlugins::Metadata do
   describe "loading" do
     it "loads additional :root plugin if was not loaded before" do
       serializer = Class.new(Serega) { plugin :metadata }

--- a/spec/serega/plugins/metadata/validations/check_block_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_block_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Serega::Plugins.find_plugin(:metadata)
+# Serega::SeregaPlugins.find_plugin(:metadata)
 load_plugin_code(:metadata)
 
-RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckBlock do
+RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckBlock do
   let(:error) { "Block can have maximum 2 regular parameters (no **keyword or *array args)" }
 
   it "allows no params" do

--- a/spec/serega/plugins/metadata/validations/check_block_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_block_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckBlock do
 
   it "prohibits three parameters" do
     block = proc { |_obj, _ctx, _foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, error
   end
 
   it "prohibits *rest parameters" do
     block = proc { |*_foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, error
   end
 
   it "prohibits **keywords parameters" do
     block = proc { |**_foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, error
   end
 end

--- a/spec/serega/plugins/metadata/validations/check_opt_hide_empty_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opt_hide_empty_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code(:metadata)
 
-RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckOptHideEmpty do
+RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideEmpty do
   def error(value)
     "Invalid option :hide_empty => #{value.inspect}. Must be true"
   end

--- a/spec/serega/plugins/metadata/validations/check_opt_hide_empty_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opt_hide_empty_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideEmpty
 
   it "allows only boolean values" do
     expect { described_class.call(hide_empty: true) }.not_to raise_error
-    expect { described_class.call(hide_empty: false) }.to raise_error Serega::Error, error(false)
-    expect { described_class.call(hide_empty: "true") }.to raise_error Serega::Error, error("true")
-    expect { described_class.call(hide_empty: nil) }.to raise_error Serega::Error, error(nil)
-    expect { described_class.call(hide_empty: 0) }.to raise_error Serega::Error, error(0)
+    expect { described_class.call(hide_empty: false) }.to raise_error Serega::SeregaError, error(false)
+    expect { described_class.call(hide_empty: "true") }.to raise_error Serega::SeregaError, error("true")
+    expect { described_class.call(hide_empty: nil) }.to raise_error Serega::SeregaError, error(nil)
+    expect { described_class.call(hide_empty: 0) }.to raise_error Serega::SeregaError, error(0)
   end
 end

--- a/spec/serega/plugins/metadata/validations/check_opt_hide_nil_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opt_hide_nil_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideNil d
 
   it "allows only boolean values" do
     expect { described_class.call(hide_nil: true) }.not_to raise_error
-    expect { described_class.call(hide_nil: false) }.to raise_error Serega::Error, error(false)
-    expect { described_class.call(hide_nil: "true") }.to raise_error Serega::Error, error("true")
-    expect { described_class.call(hide_nil: nil) }.to raise_error Serega::Error, error(nil)
-    expect { described_class.call(hide_nil: 0) }.to raise_error Serega::Error, error(0)
+    expect { described_class.call(hide_nil: false) }.to raise_error Serega::SeregaError, error(false)
+    expect { described_class.call(hide_nil: "true") }.to raise_error Serega::SeregaError, error("true")
+    expect { described_class.call(hide_nil: nil) }.to raise_error Serega::SeregaError, error(nil)
+    expect { described_class.call(hide_nil: 0) }.to raise_error Serega::SeregaError, error(0)
   end
 end

--- a/spec/serega/plugins/metadata/validations/check_opt_hide_nil_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opt_hide_nil_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code(:metadata)
 
-RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckOptHideNil do
+RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideNil do
   def error(value)
     "Invalid option :hide_nil => #{value.inspect}. Must be true"
   end

--- a/spec/serega/plugins/metadata/validations/check_opts_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOpts do
     expect { described_class.call(opts, attribute_keys) }.not_to raise_error
 
     expect { described_class.call(opts, %i[opt1]) }
-      .to raise_error Serega::Error, invalid_key_error(:opt2, %i[opt1])
+      .to raise_error Serega::SeregaError, invalid_key_error(:opt2, %i[opt1])
   end
 
   it "checks each option value" do

--- a/spec/serega/plugins/metadata/validations/check_opts_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_opts_spec.rb
@@ -2,10 +2,10 @@
 
 load_plugin_code(:metadata)
 
-RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckOpts do
+RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOpts do
   before do
-    allow(Serega::Plugins::Metadata::MetaAttribute::CheckOptHideEmpty).to receive(:call).with(opts)
-    allow(Serega::Plugins::Metadata::MetaAttribute::CheckOptHideNil).to receive(:call).with(opts)
+    allow(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideEmpty).to receive(:call).with(opts)
+    allow(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideNil).to receive(:call).with(opts)
   end
 
   let(:opts) { {opt1: :foo, opt2: :bar} }
@@ -25,7 +25,7 @@ RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckOpts do
   it "checks each option value" do
     described_class.call(opts, attribute_keys)
 
-    expect(Serega::Plugins::Metadata::MetaAttribute::CheckOptHideEmpty).to have_received(:call).with(opts)
-    expect(Serega::Plugins::Metadata::MetaAttribute::CheckOptHideNil).to have_received(:call).with(opts)
+    expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideEmpty).to have_received(:call).with(opts)
+    expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOptHideNil).to have_received(:call).with(opts)
   end
 end

--- a/spec/serega/plugins/metadata/validations/check_path_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_path_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code(:metadata)
 
-RSpec.describe Serega::Plugins::Metadata::MetaAttribute::CheckPath do
+RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
   def error(name)
     %(Invalid metadata path #{name.inspect}, globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
   end

--- a/spec/serega/plugins/metadata/validations/check_path_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_path_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
   end
 
   it "prohibits empty name" do
-    expect { described_class.call([""]) }.to raise_error Serega::Error, error("")
-    expect { described_class.call([:foo, ""]) }.to raise_error Serega::Error, error("")
+    expect { described_class.call([""]) }.to raise_error Serega::SeregaError, error("")
+    expect { described_class.call([:foo, ""]) }.to raise_error Serega::SeregaError, error("")
   end
 
   it "allows one char A-Za-z0-9" do
@@ -23,9 +23,9 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
     expect { described_class.call(["5"]) }.not_to raise_error
     expect { described_class.call(["9"]) }.not_to raise_error
 
-    expect { described_class.call(["-"]) }.to raise_error Serega::Error, error("-")
-    expect { described_class.call(["`"]) }.to raise_error Serega::Error, error("`")
-    expect { described_class.call(["_"]) }.to raise_error Serega::Error, error("_")
+    expect { described_class.call(["-"]) }.to raise_error Serega::SeregaError, error("-")
+    expect { described_class.call(["`"]) }.to raise_error Serega::SeregaError, error("`")
+    expect { described_class.call(["_"]) }.to raise_error Serega::SeregaError, error("_")
   end
 
   it "allows two chars A-Za-z0-9" do
@@ -33,11 +33,11 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
     expect { described_class.call(["Za"]) }.not_to raise_error
     expect { described_class.call(["09"]) }.not_to raise_error
 
-    expect { described_class.call(["a~"]) }.to raise_error Serega::Error, error("a~")
-    expect { described_class.call(["a-"]) }.to raise_error Serega::Error, error("a-")
-    expect { described_class.call(["-a"]) }.to raise_error Serega::Error, error("-a")
-    expect { described_class.call(["_a"]) }.to raise_error Serega::Error, error("_a")
-    expect { described_class.call(["a_"]) }.to raise_error Serega::Error, error("a_")
+    expect { described_class.call(["a~"]) }.to raise_error Serega::SeregaError, error("a~")
+    expect { described_class.call(["a-"]) }.to raise_error Serega::SeregaError, error("a-")
+    expect { described_class.call(["-a"]) }.to raise_error Serega::SeregaError, error("-a")
+    expect { described_class.call(["_a"]) }.to raise_error Serega::SeregaError, error("_a")
+    expect { described_class.call(["a_"]) }.to raise_error Serega::SeregaError, error("a_")
   end
 
   it 'allows multiple chars A-Za-z0-9 with "-" and "_" in the middle' do
@@ -47,10 +47,10 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
     expect { described_class.call(["foo-123"]) }.not_to raise_error
     expect { described_class.call(["foo_3"]) }.not_to raise_error
 
-    expect { described_class.call(["foo-"]) }.to raise_error Serega::Error, error("foo-")
-    expect { described_class.call(["foo_"]) }.to raise_error Serega::Error, error("foo_")
-    expect { described_class.call(["-foo"]) }.to raise_error Serega::Error, error("-foo")
-    expect { described_class.call(["_foo"]) }.to raise_error Serega::Error, error("_foo")
-    expect { described_class.call(["foo+bar"]) }.to raise_error Serega::Error, error("foo+bar")
+    expect { described_class.call(["foo-"]) }.to raise_error Serega::SeregaError, error("foo-")
+    expect { described_class.call(["foo_"]) }.to raise_error Serega::SeregaError, error("foo_")
+    expect { described_class.call(["-foo"]) }.to raise_error Serega::SeregaError, error("-foo")
+    expect { described_class.call(["_foo"]) }.to raise_error Serega::SeregaError, error("_foo")
+    expect { described_class.call(["foo+bar"]) }.to raise_error Serega::SeregaError, error("foo+bar")
   end
 end

--- a/spec/serega/plugins/preloads/lib/enum_deep_freeze_spec.rb
+++ b/spec/serega/plugins/preloads/lib/enum_deep_freeze_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads::EnumDeepFreeze do
+RSpec.describe Serega::SeregaPlugins::Preloads::EnumDeepFreeze do
   it "deeply freezes provided hash" do
     hash = {key1: {key11: {key111: :value111}}, key2: [{key22: {key222: :value222}}]}
     described_class.call(hash)

--- a/spec/serega/plugins/preloads/lib/format_user_preloads_spec.rb
+++ b/spec/serega/plugins/preloads/lib/format_user_preloads_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads::FormatUserPreloads do
+RSpec.describe Serega::SeregaPlugins::Preloads::FormatUserPreloads do
   let(:format) { described_class }
 
   it "transforms nil to empty hash" do

--- a/spec/serega/plugins/preloads/lib/main_preload_path_spec.rb
+++ b/spec/serega/plugins/preloads/lib/main_preload_path_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads::MainPreloadPath do
+RSpec.describe Serega::SeregaPlugins::Preloads::MainPreloadPath do
   let(:main_path) { described_class }
 
   it "returns empty array when preloads are empty" do

--- a/spec/serega/plugins/preloads/lib/preloads_constructor_spec.rb
+++ b/spec/serega/plugins/preloads/lib/preloads_constructor_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads::PreloadsConstructor do
+RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   let(:base) do
     Class.new(Serega) do
       plugin :preloads

--- a/spec/serega/plugins/preloads/preloads_spec.rb
+++ b/spec/serega/plugins/preloads/preloads_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads do
+RSpec.describe Serega::SeregaPlugins::Preloads do
   let(:serializer_class) { Class.new(Serega) }
 
   it "adds allowed attribute options" do

--- a/spec/serega/plugins/preloads/validations/check_opt_preload_path_spec.rb
+++ b/spec/serega/plugins/preloads/validations/check_opt_preload_path_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :preloads
 
-RSpec.describe Serega::Plugins::Preloads::CheckOptPreloadPath do
+RSpec.describe Serega::SeregaPlugins::Preloads::CheckOptPreloadPath do
   let(:validator) { described_class }
 
   it "does not raise error when no preload_path option" do

--- a/spec/serega/plugins/preloads/validations/check_opt_preload_path_spec.rb
+++ b/spec/serega/plugins/preloads/validations/check_opt_preload_path_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe Serega::SeregaPlugins::Preloads::CheckOptPreloadPath do
 
   it "raises error when :preload_path option provided without :preload option" do
     expect { validator.call({preload_path: :foo}) }
-      .to raise_error Serega::Error, "Invalid option :preload_path => :foo. Can be provided only when :preload option provided"
+      .to raise_error Serega::SeregaError, "Invalid option :preload_path => :foo. Can be provided only when :preload option provided"
   end
 
   it "raises error when :preload_path option provided without :serializer option" do
     expect { validator.call({preload_path: :foo, preload: :foo}) }
-      .to raise_error Serega::Error, "Invalid option :preload_path => :foo. Can be provided only when :serializer option provided"
+      .to raise_error Serega::SeregaError, "Invalid option :preload_path => :foo. Can be provided only when :serializer option provided"
   end
 
   it "raises error when :preload_path option is not included in :preload option" do
     expect { validator.call({preload_path: :foo, preload: {bar: :bazz}, serializer: :foo}) }
-      .to raise_error Serega::Error, "Invalid option :preload_path => :foo. Can be one of [:bar], [:bar, :bazz]"
+      .to raise_error Serega::SeregaError, "Invalid option :preload_path => :foo. Can be one of [:bar], [:bar, :bazz]"
   end
 
   it "does not raises error with valid :preload_path" do

--- a/spec/serega/plugins/presenter/presenter_spec.rb
+++ b/spec/serega/plugins/presenter/presenter_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :presenter
 
-RSpec.describe Serega::Plugins::Presenter do
+RSpec.describe Serega::SeregaPlugins::Presenter do
   let(:serializer) { Class.new(Serega) { plugin :presenter } }
 
   describe "loading" do

--- a/spec/serega/plugins/root/root_spec.rb
+++ b/spec/serega/plugins/root/root_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :root
 
-RSpec.describe Serega::Plugins::Root do
+RSpec.describe Serega::SeregaPlugins::Root do
   describe "serialization" do
     let(:response) { user_serializer.new.to_h(user) }
 

--- a/spec/serega/plugins/string_modifiers/parse_string_modifiers_spec.rb
+++ b/spec/serega/plugins/string_modifiers/parse_string_modifiers_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :string_modifiers
 
-RSpec.describe Serega::Plugins::StringModifiers::ParseStringModifiers do
+RSpec.describe Serega::SeregaPlugins::StringModifiers::ParseStringModifiers do
   def parse(str)
     described_class.call(str)
   end

--- a/spec/serega/plugins/string_modifiers/string_modifiers_spec.rb
+++ b/spec/serega/plugins/string_modifiers/string_modifiers_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :string_modifiers
 
-RSpec.describe Serega::Plugins::StringModifiers do
+RSpec.describe Serega::SeregaPlugins::StringModifiers do
   describe "serialization" do
     let(:response) { user_serializer.new.to_h(user) }
 

--- a/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
+++ b/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Serega::SeregaPlugins::ValidateModifiers do
     a.attribute :c, serializer: c
 
     expect { a.new(with: "a1,a2,c(c1,c2),b(b1,b2,c(c1,c2,c3)") }
-      .to raise_error Serega::Error, "Attribute 'c3' ('b.c.c3') not exists"
+      .to raise_error Serega::SeregaError, "Attribute 'c3' ('b.c.c3') not exists"
   end
 
   it "validates deeply nested fields about not existing relation" do

--- a/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
+++ b/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
@@ -2,7 +2,7 @@
 
 load_plugin_code :validate_modifiers
 
-RSpec.describe Serega::Plugins::ValidateModifiers do
+RSpec.describe Serega::SeregaPlugins::ValidateModifiers do
   let(:base_serializer) do
     serializer_class = Class.new(Serega)
     serializer_class.plugin :string_modifiers

--- a/spec/serega/plugins_spec.rb
+++ b/spec/serega/plugins_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Plugins do
+RSpec.describe Serega::SeregaPlugins do
   let(:described_module) { described_class }
 
   describe ".register_plugin" do

--- a/spec/serega/plugins_spec.rb
+++ b/spec/serega/plugins_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Serega::SeregaPlugins do
 
     it "raises specific error if plugin not found" do
       expect { described_module.find_plugin(:foo) }
-        .to raise_error Serega::Error, "Plugin 'foo' does not exist"
+        .to raise_error Serega::SeregaError, "Plugin 'foo' does not exist"
     end
 
     it "raises specific error if plugin was found by name but was not registered" do
@@ -48,7 +48,7 @@ RSpec.describe Serega::SeregaPlugins do
       File.new(plugin_path, File::CREAT)
 
       expect { described_module.find_plugin(plugin_name) }
-        .to raise_error Serega::Error, "Plugin '#{plugin_name}' did not register itself correctly"
+        .to raise_error Serega::SeregaError, "Plugin '#{plugin_name}' did not register itself correctly"
     ensure
       File.unlink(plugin_path)
       Dir.unlink(plugin_dir)

--- a/spec/serega/utils/as_json_spec.rb
+++ b/spec/serega/utils/as_json_spec.rb
@@ -3,7 +3,7 @@
 require "bigdecimal"
 require "json"
 
-RSpec.describe Serega::Utils::AsJSON do
+RSpec.describe Serega::SeregaUtils::AsJSON do
   def as_json(data)
     described_class.call(data, to_json: JSON.method(:dump))
   end

--- a/spec/serega/utils/to_hash_spec.rb
+++ b/spec/serega/utils/to_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Utils::ToHash do
+RSpec.describe Serega::SeregaUtils::ToHash do
   subject(:result) { described_class.call(val) }
 
   context "with nil value" do

--- a/spec/serega/utils/to_hash_spec.rb
+++ b/spec/serega/utils/to_hash_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { true }
 
     it "returns nested hash with symbol keys with frozen empty hash final value" do
-      expect { result }.to raise_error Serega::Error, "Cant convert TrueClass class object to hash"
+      expect { result }.to raise_error Serega::SeregaError, "Cant convert TrueClass class object to hash"
     end
   end
 

--- a/spec/serega/utils/to_json_spec.rb
+++ b/spec/serega/utils/to_json_spec.rb
@@ -3,7 +3,7 @@
 require "bigdecimal"
 require "json"
 
-RSpec.describe Serega::Utils::ToJSON do
+RSpec.describe Serega::SeregaUtils::ToJSON do
   def to_json(data)
     described_class.call(data)
   end

--- a/spec/serega/validations/attribute/check_block_spec.rb
+++ b/spec/serega/validations/attribute/check_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckBlock do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckBlock do
   let(:block_error) { "Block can have maximum two regular parameters (no **keyword or *array args)" }
   let(:block) { nil }
 

--- a/spec/serega/validations/attribute/check_block_spec.rb
+++ b/spec/serega/validations/attribute/check_block_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckBlock do
 
   it "prohibits block with three parameters" do
     block = proc { |_obj, _ctx, _foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, block_error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, block_error
   end
 
   it "prohibits *rest parameters" do
     block = proc { |*_foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, block_error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, block_error
   end
 
   it "prohibits **keywords parameters" do
     block = proc { |**_foo| }
-    expect { described_class.call(block) }.to raise_error Serega::Error, block_error
+    expect { described_class.call(block) }.to raise_error Serega::SeregaError, block_error
   end
 end

--- a/spec/serega/validations/attribute/check_name_spec.rb
+++ b/spec/serega/validations/attribute/check_name_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckName do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
   def error(name)
     %(Invalid attribute name = #{name.inspect}. Globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
   end

--- a/spec/serega/validations/attribute/check_name_spec.rb
+++ b/spec/serega/validations/attribute/check_name_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
 
   it "prohibits empty name" do
     name = ""
-    expect { described_class.call(name) }.to raise_error Serega::Error, error(name)
+    expect { described_class.call(name) }.to raise_error Serega::SeregaError, error(name)
   end
 
   it "allows one char A-Za-z0-9" do
@@ -21,9 +21,9 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
     expect { described_class.call("5") }.not_to raise_error
     expect { described_class.call("9") }.not_to raise_error
 
-    expect { described_class.call("-") }.to raise_error Serega::Error, error("-")
-    expect { described_class.call("`") }.to raise_error Serega::Error, error("`")
-    expect { described_class.call("_") }.to raise_error Serega::Error, error("_")
+    expect { described_class.call("-") }.to raise_error Serega::SeregaError, error("-")
+    expect { described_class.call("`") }.to raise_error Serega::SeregaError, error("`")
+    expect { described_class.call("_") }.to raise_error Serega::SeregaError, error("_")
   end
 
   it "allows two chars A-Za-z0-9" do
@@ -31,11 +31,11 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
     expect { described_class.call("Za") }.not_to raise_error
     expect { described_class.call("09") }.not_to raise_error
 
-    expect { described_class.call("a~") }.to raise_error Serega::Error, error("a~")
-    expect { described_class.call("a-") }.to raise_error Serega::Error, error("a-")
-    expect { described_class.call("-a") }.to raise_error Serega::Error, error("-a")
-    expect { described_class.call("_a") }.to raise_error Serega::Error, error("_a")
-    expect { described_class.call("a_") }.to raise_error Serega::Error, error("a_")
+    expect { described_class.call("a~") }.to raise_error Serega::SeregaError, error("a~")
+    expect { described_class.call("a-") }.to raise_error Serega::SeregaError, error("a-")
+    expect { described_class.call("-a") }.to raise_error Serega::SeregaError, error("-a")
+    expect { described_class.call("_a") }.to raise_error Serega::SeregaError, error("_a")
+    expect { described_class.call("a_") }.to raise_error Serega::SeregaError, error("a_")
   end
 
   it 'allows multiple chars A-Za-z0-9 with "-" and "_" in the middle' do
@@ -45,10 +45,10 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
     expect { described_class.call("foo-123") }.not_to raise_error
     expect { described_class.call("foo_3") }.not_to raise_error
 
-    expect { described_class.call("foo-") }.to raise_error Serega::Error, error("foo-")
-    expect { described_class.call("foo_") }.to raise_error Serega::Error, error("foo_")
-    expect { described_class.call("-foo") }.to raise_error Serega::Error, error("-foo")
-    expect { described_class.call("_foo") }.to raise_error Serega::Error, error("_foo")
-    expect { described_class.call("foo+bar") }.to raise_error Serega::Error, error("foo+bar")
+    expect { described_class.call("foo-") }.to raise_error Serega::SeregaError, error("foo-")
+    expect { described_class.call("foo_") }.to raise_error Serega::SeregaError, error("foo_")
+    expect { described_class.call("-foo") }.to raise_error Serega::SeregaError, error("-foo")
+    expect { described_class.call("_foo") }.to raise_error Serega::SeregaError, error("_foo")
+    expect { described_class.call("foo+bar") }.to raise_error Serega::SeregaError, error("foo+bar")
   end
 end

--- a/spec/serega/validations/attribute/check_opt_const_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_const_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe Serega::SeregaValidations::Attribute::CheckOptConst do
   it "prohibits to use with :value opt" do
     expect { described_class.call(const: :foo, value: -> {}) }
-      .to raise_error Serega::Error, "Option :const can not be used together with option :value"
+      .to raise_error Serega::SeregaError, "Option :const can not be used together with option :value"
   end
 
   it "prohibits to use with :key opt" do
     expect { described_class.call(key: :foo, const: 1) }
-      .to raise_error Serega::Error, "Option :const can not be used together with option :key"
+      .to raise_error Serega::SeregaError, "Option :const can not be used together with option :key"
   end
 
   it "prohibits to use with block" do
     expect { described_class.call({const: :foo}, proc {}) }
-      .to raise_error Serega::Error, "Option :const can not be used together with block"
+      .to raise_error Serega::SeregaError, "Option :const can not be used together with block"
   end
 end

--- a/spec/serega/validations/attribute/check_opt_const_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_const_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptConst do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptConst do
   it "prohibits to use with :value opt" do
     expect { described_class.call(const: :foo, value: -> {}) }
       .to raise_error Serega::Error, "Option :const can not be used together with option :value"

--- a/spec/serega/validations/attribute/check_opt_hide_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_hide_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptHide do
   it "allows only boolean values" do
     expect { described_class.call(hide: true) }.not_to raise_error
     expect { described_class.call(hide: false) }.not_to raise_error
-    expect { described_class.call(hide: nil) }.to raise_error Serega::Error, error(nil)
-    expect { described_class.call(hide: 0) }.to raise_error Serega::Error, error(0)
+    expect { described_class.call(hide: nil) }.to raise_error Serega::SeregaError, error(nil)
+    expect { described_class.call(hide: 0) }.to raise_error Serega::SeregaError, error(0)
   end
 end

--- a/spec/serega/validations/attribute/check_opt_hide_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_hide_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptHide do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptHide do
   def error(value)
     "Invalid option :hide => #{value.inspect}. Must have a boolean value"
   end

--- a/spec/serega/validations/attribute/check_opt_key_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_key_spec.rb
@@ -8,22 +8,22 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptKey do
   it "allows only boolean values" do
     expect { described_class.call(key: :foo) }.not_to raise_error
     expect { described_class.call(key: "foo") }.not_to raise_error
-    expect { described_class.call(key: nil) }.to raise_error Serega::Error, error(nil)
-    expect { described_class.call(key: 123) }.to raise_error Serega::Error, error(123)
+    expect { described_class.call(key: nil) }.to raise_error Serega::SeregaError, error(nil)
+    expect { described_class.call(key: 123) }.to raise_error Serega::SeregaError, error(123)
   end
 
   it "prohibits to use with :value opt" do
     expect { described_class.call(key: :foo, value: -> {}) }
-      .to raise_error Serega::Error, "Option :key can not be used together with option :value"
+      .to raise_error Serega::SeregaError, "Option :key can not be used together with option :value"
   end
 
   it "prohibits to use with :const opt" do
     expect { described_class.call(key: :foo, const: 1) }
-      .to raise_error Serega::Error, "Option :key can not be used together with option :const"
+      .to raise_error Serega::SeregaError, "Option :key can not be used together with option :const"
   end
 
   it "prohibits to use with block" do
     expect { described_class.call({key: :foo}, proc {}) }
-      .to raise_error Serega::Error, "Option :key can not be used together with block"
+      .to raise_error Serega::SeregaError, "Option :key can not be used together with block"
   end
 end

--- a/spec/serega/validations/attribute/check_opt_key_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_key_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptKey do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptKey do
   def error(value)
     "Invalid option :key => #{value.inspect}. Must be a String or a Symbol"
   end

--- a/spec/serega/validations/attribute/check_opt_many_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_many_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptMany do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptMany do
   def error(value)
     "Invalid option :many => #{value.inspect}. Must have a boolean value"
   end

--- a/spec/serega/validations/attribute/check_opt_many_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_many_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptMany do
   it "allows only boolean values" do
     expect { described_class.call(many: true) }.not_to raise_error
     expect { described_class.call(many: false) }.not_to raise_error
-    expect { described_class.call(many: nil) }.to raise_error Serega::Error, error(nil)
-    expect { described_class.call(many: 0) }.to raise_error Serega::Error, error(0)
+    expect { described_class.call(many: nil) }.to raise_error Serega::SeregaError, error(nil)
+    expect { described_class.call(many: 0) }.to raise_error Serega::SeregaError, error(0)
   end
 end

--- a/spec/serega/validations/attribute/check_opt_serializer_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_serializer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptSerializer do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptSerializer do
   def error(value)
     "Invalid option :serializer => #{value.inspect}. Can be a Serega subclass, a String or a Proc without arguments"
   end

--- a/spec/serega/validations/attribute/check_opt_value_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_value_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Attribute::CheckOptValue do
+RSpec.describe Serega::SeregaValidations::Attribute::CheckOptValue do
   let(:value_error) { "Option :value must be a Proc that is able to accept two parameters (no **keyword or *array args)" }
   let(:opts) { {} }
 

--- a/spec/serega/validations/attribute/check_opt_value_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_value_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptValue do
 
   it "prohibits to use with :key opt" do
     expect { described_class.call({value: proc {}, key: :foo}) }
-      .to raise_error Serega::Error, "Option :value can not be used together with option :key"
+      .to raise_error Serega::SeregaError, "Option :value can not be used together with option :key"
   end
 
   it "prohibits to use with :const opt" do
     expect { described_class.call(value: proc {}, const: 1) }
-      .to raise_error Serega::Error, "Option :value can not be used together with option :const"
+      .to raise_error Serega::SeregaError, "Option :value can not be used together with option :const"
   end
 
   it "prohibits to use with block" do
     expect { described_class.call({value: proc {}}, proc {}) }
-      .to raise_error Serega::Error, "Option :value can not be used together with block"
+      .to raise_error Serega::SeregaError, "Option :value can not be used together with block"
   end
 
   it "allows value with no params" do
@@ -26,7 +26,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptValue do
 
   it "prohibits value defined as lambda without params" do
     opts[:value] = -> {}
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 
   it "allows value with one parameter" do
@@ -36,7 +36,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptValue do
 
   it "prohibits lambda value with one parameter" do
     opts[:value] = ->(_obj) {}
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 
   it "allows value with two parameters" do
@@ -51,21 +51,21 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptValue do
 
   it "prohibits value with three parameters" do
     opts[:value] = proc { |_obj, _ctx, _foo| }
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 
   it "prohibits lambda value with three parameters" do
     opts[:value] = ->(_obj, _ctx, _foo) {}
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 
   it "prohibits lambda with *rest parameters" do
     opts[:value] = ->(_obj, *_ctx) {}
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 
   it "prohibits lambda with *keywords parameters" do
     opts[:value] = ->(_obj, **_ctx) {}
-    expect { described_class.call(opts) }.to raise_error Serega::Error, value_error
+    expect { described_class.call(opts) }.to raise_error Serega::SeregaError, value_error
   end
 end

--- a/spec/serega/validations/check_attribute_params_spec.rb
+++ b/spec/serega/validations/check_attribute_params_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::CheckAttributeParams do
+RSpec.describe Serega::SeregaValidations::CheckAttributeParams do
   subject(:validate) { described_class.new(*params).validate }
 
   let(:serializer) do
@@ -18,32 +18,32 @@ RSpec.describe Serega::Validations::CheckAttributeParams do
   let(:described_class) { serializer::CheckAttributeParams }
 
   before do
-    allow(Serega::Validations::Utils::CheckAllowedKeys).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckBlock).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckName).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptConst).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptHide).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptKey).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptMany).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptSerializer).to receive(:call)
-    allow(Serega::Validations::Attribute::CheckOptValue).to receive(:call)
+    allow(Serega::SeregaValidations::SeregaUtils::CheckAllowedKeys).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckBlock).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckName).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptConst).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptHide).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptKey).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptMany).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptSerializer).to receive(:call)
+    allow(Serega::SeregaValidations::Attribute::CheckOptValue).to receive(:call)
   end
 
   it "checks valid keys" do
     validate
-    expect(Serega::Validations::Utils::CheckAllowedKeys).to have_received(:call).with(opts, attribute_keys)
+    expect(Serega::SeregaValidations::SeregaUtils::CheckAllowedKeys).to have_received(:call).with(opts, attribute_keys)
   end
 
   it "checks each option value" do
     validate
 
-    expect(Serega::Validations::Attribute::CheckBlock).to have_received(:call).with(block)
-    expect(Serega::Validations::Attribute::CheckName).to have_received(:call).with(name)
-    expect(Serega::Validations::Attribute::CheckOptConst).to have_received(:call).with(opts, block)
-    expect(Serega::Validations::Attribute::CheckOptHide).to have_received(:call).with(opts)
-    expect(Serega::Validations::Attribute::CheckOptKey).to have_received(:call).with(opts, block)
-    expect(Serega::Validations::Attribute::CheckOptMany).to have_received(:call).with(opts)
-    expect(Serega::Validations::Attribute::CheckOptSerializer).to have_received(:call).with(opts)
-    expect(Serega::Validations::Attribute::CheckOptValue).to have_received(:call).with(opts, block)
+    expect(Serega::SeregaValidations::Attribute::CheckBlock).to have_received(:call).with(block)
+    expect(Serega::SeregaValidations::Attribute::CheckName).to have_received(:call).with(name)
+    expect(Serega::SeregaValidations::Attribute::CheckOptConst).to have_received(:call).with(opts, block)
+    expect(Serega::SeregaValidations::Attribute::CheckOptHide).to have_received(:call).with(opts)
+    expect(Serega::SeregaValidations::Attribute::CheckOptKey).to have_received(:call).with(opts, block)
+    expect(Serega::SeregaValidations::Attribute::CheckOptMany).to have_received(:call).with(opts)
+    expect(Serega::SeregaValidations::Attribute::CheckOptSerializer).to have_received(:call).with(opts)
+    expect(Serega::SeregaValidations::Attribute::CheckOptValue).to have_received(:call).with(opts, block)
   end
 end

--- a/spec/serega/validations/utils/check_allowed_keys_spec.rb
+++ b/spec/serega/validations/utils/check_allowed_keys_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Utils::CheckAllowedKeys do
+RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckAllowedKeys do
   let(:opts) { {opt1: :foo, opt2: :bar} }
   let(:attribute_keys) { %i[opt1 opt2] }
 

--- a/spec/serega/validations/utils/check_allowed_keys_spec.rb
+++ b/spec/serega/validations/utils/check_allowed_keys_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckAllowedKeys do
     expect { described_class.call(opts, attribute_keys) }.not_to raise_error
 
     expect { described_class.call(opts, %i[opt1]) }
-      .to raise_error Serega::Error, invalid_key_error(:opt2, %i[opt1])
+      .to raise_error Serega::SeregaError, invalid_key_error(:opt2, %i[opt1])
   end
 end

--- a/spec/serega/validations/utils/check_opt_is_hash_spec.rb
+++ b/spec/serega/validations/utils/check_opt_is_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Utils::CheckOptIsHash do
+RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckOptIsHash do
   def error(key, value)
     "Invalid option #{key.inspect} => #{value.inspect}. Must have a Hash value"
   end

--- a/spec/serega/validations/utils/check_opt_is_hash_spec.rb
+++ b/spec/serega/validations/utils/check_opt_is_hash_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckOptIsHash do
   it "allows only boolean values" do
     expect { described_class.call({many: {}}, :many) }.not_to raise_error
     expect { described_class.call({many: {foo: []}}, :many) }.not_to raise_error
-    expect { described_class.call({many: []}, :many) }.to raise_error Serega::Error, error(:many, [])
-    expect { described_class.call({many: nil}, :many) }.to raise_error Serega::Error, error(:many, nil)
-    expect { described_class.call({many: 0}, :many) }.to raise_error Serega::Error, error(:many, 0)
+    expect { described_class.call({many: []}, :many) }.to raise_error Serega::SeregaError, error(:many, [])
+    expect { described_class.call({many: nil}, :many) }.to raise_error Serega::SeregaError, error(:many, nil)
+    expect { described_class.call({many: 0}, :many) }.to raise_error Serega::SeregaError, error(:many, 0)
   end
 end

--- a/spec/serega/validations/utils/check_opt_is_string_or_symbol_spec.rb
+++ b/spec/serega/validations/utils/check_opt_is_string_or_symbol_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Utils::CheckOptIsStringOrSymbol do
+RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckOptIsStringOrSymbol do
   def error(key, value)
     "Invalid option #{key.inspect} => #{value.inspect}. Must be a String or a Symbol"
   end

--- a/spec/serega/validations/utils/check_opts_is_bool_spec.rb
+++ b/spec/serega/validations/utils/check_opts_is_bool_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckOptIsBool do
   it "allows only boolean values" do
     expect { described_class.call({many: true}, :many) }.not_to raise_error
     expect { described_class.call({many: false}, :many) }.not_to raise_error
-    expect { described_class.call({many: nil}, :many) }.to raise_error Serega::Error, error(:many, nil)
-    expect { described_class.call({many: 0}, :many) }.to raise_error Serega::Error, error(:many, 0)
+    expect { described_class.call({many: nil}, :many) }.to raise_error Serega::SeregaError, error(:many, nil)
+    expect { described_class.call({many: 0}, :many) }.to raise_error Serega::SeregaError, error(:many, 0)
   end
 end

--- a/spec/serega/validations/utils/check_opts_is_bool_spec.rb
+++ b/spec/serega/validations/utils/check_opts_is_bool_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::Validations::Utils::CheckOptIsBool do
+RSpec.describe Serega::SeregaValidations::SeregaUtils::CheckOptIsBool do
   def error(key, value)
     "Invalid option #{key.inspect} => #{value.inspect}. Must have a boolean value"
   end

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Serega do
       child = Class.new(parent)
 
       # Check child serialization classes are subclassed from parent classes
-      expect(child::Convert.superclass).to eq parent::Convert
-      expect(child::ConvertItem.superclass).to eq parent::ConvertItem
+      expect(child::SeregaConvert.superclass).to eq parent::SeregaConvert
+      expect(child::SeregaConvertItem.superclass).to eq parent::SeregaConvertItem
     end
   end
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Serega do
 
     it "raises error if plugin is already loaded" do
       serializer_class.plugin(plugin)
-      expect { serializer_class.plugin(plugin) }.to raise_error Serega::Error, "This plugin is already loaded"
+      expect { serializer_class.plugin(plugin) }.to raise_error Serega::SeregaError, "This plugin is already loaded"
     end
   end
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Serega do
         end
       end
 
-      Serega::Plugins.register_plugin(plugin.plugin_name, plugin)
+      Serega::SeregaPlugins.register_plugin(plugin.plugin_name, plugin)
 
       serializer_class.plugin(:test)
       expect(serializer_class.config[:plugins]).to eq [:test]
@@ -125,7 +125,7 @@ RSpec.describe Serega do
         end
       end
 
-      Serega::Plugins.register_plugin(plugin.plugin_name, plugin)
+      Serega::SeregaPlugins.register_plugin(plugin.plugin_name, plugin)
 
       expect(serializer_class.plugin_used?(:test)).to be false
       serializer_class.plugin(:test)


### PR DESCRIPTION
Fixes https://github.com/aglushkov/serega/issues/19

Add prefix Serega for Serega::* classes. Previously in serializers that use top-level classes with same  names, they should have been defined with two colons "::"