### PR TITLE
Prohibit to use option :preload together with option :const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Prohibit to use option :preload together with option :const (#23)
+
 - Rename constants. Add prefix Serega for come classes. Previously in applications that use same class names this classes have to be defined with two colons "::".
   - Serega::Attribute -> Serega::SeregaAttribute
   - Serega::Convert -> Serega::SeregaConvert

--- a/lib/serega/plugins/preloads/preloads.rb
+++ b/lib/serega/plugins/preloads/preloads.rb
@@ -29,6 +29,7 @@ class Serega
         require_relative "./lib/format_user_preloads"
         require_relative "./lib/main_preload_path"
         require_relative "./lib/preloads_constructor"
+        require_relative "./validations/check_opt_preload"
         require_relative "./validations/check_opt_preload_path"
       end
 
@@ -107,6 +108,7 @@ class Serega
 
         def check_opts
           super
+          CheckOptPreload.call(opts)
           CheckOptPreloadPath.call(opts)
         end
       end

--- a/lib/serega/plugins/preloads/validations/check_opt_preload.rb
+++ b/lib/serega/plugins/preloads/validations/check_opt_preload.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaPlugins
+    module Preloads
+      class CheckOptPreload
+        class << self
+          def call(opts)
+            return unless opts.key?(:preload)
+
+            raise SeregaError, "Option :preload can not be used together with option :const" if opts.key?(:const)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serega/plugins/preloads/preloads_spec.rb
+++ b/spec/serega/plugins/preloads/preloads_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Serega::SeregaPlugins::Preloads do
       end
     end
 
+    describe "checking preload option" do
+      let(:validator) { described_class::CheckOptPreload }
+
+      it "validates options with CheckOptPreload" do
+        allow(validator).to receive(:call).and_return(nil)
+        attribute = serializer_class.attribute :foo
+        expect(validator).to have_received(:call).with(attribute.opts)
+      end
+    end
+
     describe "checking preload_path option" do
       let(:validator) { described_class::CheckOptPreloadPath }
 

--- a/spec/serega/plugins/preloads/validations/check_opt_preload_spec.rb
+++ b/spec/serega/plugins/preloads/validations/check_opt_preload_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+load_plugin_code :preloads
+
+RSpec.describe Serega::SeregaPlugins::Preloads::CheckOptPreload do
+  it "prohibits to use with :const opt" do
+    expect { described_class.call(preload: :foo, const: 1) }
+      .to raise_error Serega::SeregaError, "Option :preload can not be used together with option :const"
+  end
+end


### PR DESCRIPTION
https://github.com/aglushkov/serega/issues/17

This looks like incorrect to use them together, if value is already defined than it is no sense to preload anything