### PR TITLE
Allow to auto preload delegated resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 ## [Unreleased]
 
+- Add config option for `:preload` plugin  - `:auto_preload_attributes_with_delegate`.
+  ```ruby
+    # Setup:
+    class Serega
+      plugin :preload, auto_preload_attributes_with_delegate: true
+      # or
+      plugin :preload
+      config[:preload][:auto_preload_attributes_with_delegate] = true
+    end
+  ```
+
 - Add option :delegate when defining attributes.
   Examples:
-  ```
+  ```ruby
     attribute :comments_count, delegate: { to: :user_stat }
     attribute :address_line_1, key: :line_1, delegate: { to: :address, allow_nil: true }
   ```

--- a/README.md
+++ b/README.md
@@ -108,15 +108,16 @@
       attribute :tags, hide: true
 
       # Option :delegate
+      # With plugin :preload and enabled :auto_preload_attributes_with_delegate option it also preloads delegated resource.
       #
       # Same as:
-      #     attribute(:posts_count) { |user| user.stat.posts_count }
+      #     attribute(:posts_count, preload: :stat) { |user| user.stat.posts_count }
       attribute :posts_count, delegate: { to: :stat }
 
       # Option :delegate with :allow_nil
       #
       # Same as:
-      #     attribute(:address_line_1, key: :line_1) { |user| user.address&.line1 }
+      #     attribute(:address_line_1, key: :line_1, preload: :address) { |user| user.address&.line1 }
       attribute :address_line_1, key: :line_1, delegate: { to: :address, allow_nil: true }
 
       # Option :serializer specifies nested serializer for attribute
@@ -162,14 +163,17 @@
 
   Config option `config[:preloads][:auto_preload_attributes_with_serializer] = true` can be specified to automatically add `preload: <attribute_key>` to all attributes with `:serializer` option.
 
+  Config option `config[:preloads][:auto_preload_attributes_with_delegate] = true` can be specified to automatically add `preload: <delegate_to>` to all attributes with `:delegate` option.
+
   Config option `config[:preloads][:auto_hide_attributes_with_preload] = true` can be specified to automatically add `hide: true` to all attributes with any `:preload`. It also works for automatically assigned preloads.
 
-  Preloads can be disabled with `preload: false` option. Or auto added preloads can be overwritten with `preload: <another_key>` option.
+  Preloads can be disabled with `preload: false` option. Also auto added preloads can be overwritten with `preload: <another_key>` option.
 
   ```ruby
     class AppSerializer < Serega
       plugin :preloads,
         auto_preload_attributes_with_serializer: true,
+        auto_preload_attributes_with_delegate: true,
         auto_hide_attributes_with_preload: true
     end
 
@@ -179,10 +183,10 @@
     end
 
     class UserSerializer  < AppSerializer
-      attribute :followers_count, preload: :user_stats, value: proc { |user| user.user_stats.followers_count  }
+      attribute :followers_count, delegate: {to: :user_stats}
     end
 
-    PostSerializer.preloads # => {:views_stats=>{}, :user=>{:user_stats=>{}}}
+    PostSerializer.new(only: [:views_count, user: :followers_count]).preloads # => {:views_stats=>{}, :user=>{:user_stats=>{}}}
   ```
 
 ### Plugin :activerecord_preloads

--- a/lib/serega/plugins/preloads/preloads.rb
+++ b/lib/serega/plugins/preloads/preloads.rb
@@ -37,6 +37,7 @@ class Serega
         config = serializer_class.config
         config[:attribute_keys] += [:preload, :preload_path]
         config[:preloads] = {
+          auto_preload_attributes_with_delegate: opts.fetch(:auto_preload_attributes_with_delegate, false),
           auto_preload_attributes_with_serializer: opts.fetch(:auto_preload_attributes_with_serializer, false),
           auto_hide_attributes_with_preload: opts.fetch(:auto_hide_attributes_with_preload, false)
         }
@@ -87,6 +88,8 @@ class Serega
               opts[:preload]
             elsif relation? && self.class.serializer_class.config[:preloads][:auto_preload_attributes_with_serializer]
               key
+            elsif opts.key?(:delegate) && self.class.serializer_class.config[:preloads][:auto_preload_attributes_with_delegate]
+              opts[:delegate].fetch(:to)
             end
 
           # Nil and empty hash differs as we can preload nested results to

--- a/spec/serega/plugins/preloads/preloads_spec.rb
+++ b/spec/serega/plugins/preloads/preloads_spec.rb
@@ -17,14 +17,24 @@ RSpec.describe Serega::SeregaPlugins::Preloads do
     expect(serializer_class.config[:preloads][:auto_preload_attributes_with_serializer]).to be false
   end
 
+  it "configures to not preload attributes with :delegate option by default" do
+    serializer_class.plugin :preloads
+    expect(serializer_class.config[:preloads][:auto_preload_attributes_with_delegate]).to be false
+  end
+
   it "configures to not hide attributes with preload option by default" do
     serializer_class.plugin :preloads
     expect(serializer_class.config[:preloads][:auto_hide_attributes_with_preload]).to be false
   end
 
-  it "allows to configure to preload relations by default" do
+  it "allows to configure to preload attributes with serializer by default" do
     serializer_class.plugin :preloads, auto_preload_attributes_with_serializer: true
     expect(serializer_class.config[:preloads][:auto_preload_attributes_with_serializer]).to be true
+  end
+
+  it "allows to configure to preload attributes with :delegate option by default" do
+    serializer_class.plugin :preloads, auto_preload_attributes_with_delegate: true
+    expect(serializer_class.config[:preloads][:auto_preload_attributes_with_delegate]).to be true
   end
 
   it "allows to configure to hide attributes with preloads by default" do
@@ -71,6 +81,17 @@ RSpec.describe Serega::SeregaPlugins::Preloads do
 
       it "returns no preloads for attributes with serializer by default" do
         attribute = serializer_class.attribute :foo, serializer: "bar"
+        expect(attribute.preloads).to eq({})
+      end
+
+      it "returns automatically found preloads when :delegate option provided" do
+        serializer_class.config[:preloads][:auto_preload_attributes_with_delegate] = true
+        attribute = serializer_class.attribute :foo, delegate: {to: :bar}
+        expect(attribute.preloads).to eq(bar: {})
+      end
+
+      it "returns no preloads for attributes with :delegate option by default" do
+        attribute = serializer_class.attribute :foo, delegate: {to: :bar}
         expect(attribute.preloads).to eq({})
       end
     end


### PR DESCRIPTION
https://github.com/aglushkov/serega/issues/24

Add config option for `:preload` plugin  - `:auto_preload_attributes_with_delegate`.
```ruby
  # Setup:
  class Serega
    plugin :preload, auto_preload_attributes_with_delegate: true
    # or
    plugin :preload
    config[:preload][:auto_preload_attributes_with_delegate] = true
  end
```