### PR TITLE
Remove `.relation` DSL method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+- Remove `.relation` DSL method for simplicity. Just use `attribute :foo, serializer: Foo`. Method can be returned manually:
+  ```ruby
+  class Serega
+    def self.relation(name, serializer:, **opts, &block)
+      attribute(name, serializer: serializer, **opts, &block)
+    end
+  end
+```
+
 - Add config option for `:preload` plugin  - `:auto_preload_attributes_with_delegate`.
   ```ruby
     # Setup:

--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@
       attribute :posts, serializer: "PostSerializer"
       attribute :posts, serializer: -> { PostSerializer }
 
-      # We can use `relation` word to describe attributes with serializers
-      relation :posts, serializer: PostSerializer
-
       # Option `:many` specifies a has_many relationship
       # Usually it is defined automatically by checking `value.is_a?(Enumerable)`
       attribute :posts, serializer: PostSerializer, many: true

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -20,8 +20,8 @@ class UserSerializer < AppSerializer
   attribute :id
   attribute(:name) { |user| [user.first_name, user.last_name].join(" ") }
 
-  relation :profile, serializer: "ProfileSerializer"
-  relation :roles, serializer: "RoleSerializer"
+  attribute :profile, serializer: "ProfileSerializer"
+  attribute :roles, serializer: "RoleSerializer"
 end
 
 class ProfileSerializer < AppSerializer

--- a/examples/hide_attributes.rb
+++ b/examples/hide_attributes.rb
@@ -20,8 +20,8 @@ class UserSerializer < AppSerializer
   attribute :name
   attribute :email, hide: true
 
-  relation :avatar, serializer: "AvatarSerializer"
-  relation :profile, serializer: "ProfileSerializer", hide: true
+  attribute :avatar, serializer: "AvatarSerializer"
+  attribute :profile, serializer: "ProfileSerializer", hide: true
 end
 
 class AvatarSerializer < AppSerializer

--- a/examples/preloads.rb
+++ b/examples/preloads.rb
@@ -80,17 +80,17 @@ end
 class UserSerializer < SimpleSerializer
   attribute :first_name
   attribute :last_name
-  relation :posts, serializer: -> { PostSerializer }
+  attribute :posts, serializer: -> { PostSerializer }
 end
 
 class PostSerializer < SimpleSerializer
   attribute :text
-  relation :comments, serializer: -> { CommentSerializer }
+  attribute :comments, serializer: -> { CommentSerializer }
 end
 
 class CommentSerializer < SimpleSerializer
   attribute :text
-  # relation :user, serializer: -> { UserSerializer }
+  # attribute :user, serializer: -> { UserSerializer }
 end
 
 # We need to show just DB queries in this examples to show we have no N+1
@@ -165,7 +165,7 @@ example("Relation included posts:") do
   UserSerializer.new.to_h(users)
 end
 
-example("Loaded relation included posts:") do
+example("Loaded attribute included posts:") do
   users = User.all.includes(:posts).load
   UserSerializer.new.to_h(users)
 end

--- a/examples/presenter.rb
+++ b/examples/presenter.rb
@@ -20,7 +20,7 @@ end
 class UserSerializer < AppSerializer
   attribute :id
   attribute :name
-  relation :profile, serializer: "ProfileSerializer"
+  attribute :profile, serializer: "ProfileSerializer"
 
   class Presenter
     def name

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -183,20 +183,6 @@ class Serega
       attributes[attribute.name] = attribute
     end
 
-    #
-    # Adds attribute with forced :serializer option
-    #
-    # @param name [Symbol] Attribute name. Attribute value will be found by executing `object.<name>`
-    # @param serializer [Serega, Proc] Specifies nested serializer for relationship
-    # @param opts [Hash] Options for attribute serialization
-    # @param block [Proc] Custom block to find attribute value. Accepts object and context.
-    #
-    # @return [Serega::SeregaAttribute] Added attribute
-    #
-    def relation(name, serializer:, **opts, &block)
-      attribute(name, serializer: serializer, **opts, &block)
-    end
-
     def call(object, opts = FROZEN_EMPTY_HASH)
       initiate_keys = config[:initiate_keys]
       new(opts.slice(*initiate_keys)).to_h(object, opts.except(*initiate_keys))

--- a/spec/serega/convert_spec.rb
+++ b/spec/serega/convert_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comment, serializer: child_serializer
+        attribute :comment, serializer: child_serializer
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comments, serializer: child_serializer
+        attribute :comments, serializer: child_serializer
       end
     end
 
@@ -201,7 +201,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name, hide: true
-        relation :comment, serializer: child_serializer, hide: true
+        attribute :comment, serializer: child_serializer, hide: true
       end
     end
 
@@ -226,7 +226,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comment, serializer: child_serializer
+        attribute :comment, serializer: child_serializer
       end
     end
 
@@ -251,7 +251,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comment, serializer: child_serializer
+        attribute :comment, serializer: child_serializer
       end
     end
 
@@ -276,7 +276,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comment, serializer: child_serializer
+        attribute :comment, serializer: child_serializer
       end
     end
 
@@ -301,7 +301,7 @@ RSpec.describe Serega::SeregaConvert do
       Class.new(Serega) do
         attribute :first_name
         attribute :last_name
-        relation :comment, serializer: child_serializer
+        attribute :comment, serializer: child_serializer
       end
     end
 

--- a/spec/serega/plugins/preloads/lib/preloads_constructor_spec.rb
+++ b/spec/serega/plugins/preloads/lib/preloads_constructor_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
 
   it "returns preloads generated automatically for relations" do
     user_serializer.config[:preloads][:auto_preload_attributes_with_serializer] = true
-    user_serializer.relation :email, serializer: base
+    user_serializer.attribute :email, serializer: base
 
     result = described_class.call(map(user_ser))
     expect(result).to eq(email: {})
   end
 
   it "returns no preloads and no nested preloads for relations when specified preloads is nil" do
-    user_serializer.relation :profile, serializer: profile_serializer, preload: nil
+    user_serializer.attribute :profile, serializer: profile_serializer, preload: nil
     profile_serializer.attribute :email, preload: :email # should not be preloaded
 
     result = described_class.call(map(user_ser))
@@ -62,7 +62,7 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   end
 
   it "returns preloads for nested relations joined to root when specified preloads is empty hash" do
-    user_serializer.relation :profile, serializer: profile_serializer, preload: {}
+    user_serializer.attribute :profile, serializer: profile_serializer, preload: {}
     profile_serializer.attribute :email, preload: :email # should be preloaded to root
 
     result = described_class.call(map(user_ser))
@@ -70,7 +70,7 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   end
 
   it "returns preloads for nested relations joined to root when specified preloads is empty array" do
-    user_serializer.relation :profile, serializer: profile_serializer, preload: []
+    user_serializer.attribute :profile, serializer: profile_serializer, preload: []
     profile_serializer.attribute :email, preload: :email # should be preloaded to root
 
     result = described_class.call(map(user_ser))
@@ -78,7 +78,7 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   end
 
   it "returns nested preloads for relations" do
-    user_serializer.relation :profile, preload: :profile, serializer: profile_serializer
+    user_serializer.attribute :profile, preload: :profile, serializer: profile_serializer
     profile_serializer.attribute :email, preload: %i[confirmed_email unconfirmed_email]
 
     result = described_class.call(map(user_ser))
@@ -86,7 +86,7 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   end
 
   it "preloads nested relations for nested relation" do
-    user_serializer.relation :profile, serializer: profile_serializer, preload: {company: :profile}
+    user_serializer.attribute :profile, serializer: profile_serializer, preload: {company: :profile}
     profile_serializer.attribute :email, preload: %i[confirmed_email unconfirmed_email]
 
     result = described_class.call(map(user_ser))
@@ -94,7 +94,7 @@ RSpec.describe Serega::SeregaPlugins::Preloads::PreloadsConstructor do
   end
 
   it "preloads nested relations to main resource, specified by `preload_path`" do
-    user_serializer.relation :profile, serializer: profile_serializer,
+    user_serializer.attribute :profile, serializer: profile_serializer,
       preload: {company: :profile},
       preload_path: :company
 

--- a/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
+++ b/spec/serega/plugins/validate_modifiers/validate_modifiers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Serega::SeregaPlugins::ValidateModifiers do
   let(:serializer) do
     serializer_class = Class.new(base_serializer)
     serializer_class.attribute :foo_bar
-    serializer_class.relation :foo_bazz, serializer: serializer_class
+    serializer_class.attribute :foo_bazz, serializer: serializer_class
     serializer_class
   end
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -153,17 +153,6 @@ RSpec.describe Serega do
     end
   end
 
-  describe ".relation" do
-    it "forces using of :serializer option" do
-      expect { serializer_class.relation :foo }.to raise_error ArgumentError, /serializer/
-    end
-
-    it "adds new attribute" do
-      attribute = serializer_class.relation(:foo, serializer: serializer_class)
-      expect(serializer_class.attributes[:foo]).to eq attribute
-    end
-  end
-
   describe "serialization methods" do
     let(:serializer_class) do
       Class.new(described_class) do


### PR DESCRIPTION
I want to make gem simpler.

Just use `attribute :foo, serializer: Foo`.

Method `relation` can be returned manually:
```ruby
  class AppSerializer < Serega
    def self.relation(name, serializer:, **opts, &block)
      attribute(name, serializer: serializer, **opts, &block)
    end
  end
```