### PR TITLE
Better NoMethodError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Show current serializer and attribute when NoMethodError happens
+- Fix extra db request for attributes with :batch and :serialzier options
+
 ## [0.8.1] - 2022-12-11
 
 - Change requested fields validation message. Now we return all not existing fields instead of first one.

--- a/lib/serega/plugins/batch/lib/batch_option_model.rb
+++ b/lib/serega/plugins/batch/lib/batch_option_model.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaPlugins
+    module Batch
+      #
+      # Combines options and methods needed to load batch for specific attribute
+      #
+      class BatchOptionModel
+        attr_reader :attribute, :opts, :loaders, :many
+
+        #
+        # Initializes BatchOptionModel
+        #
+        # @param map_point [Serega::SeregaMapPoint] Map point for attribute with :batch option
+        # @param loaders [Array] Array of all loaders defined in serialize class
+        # @param many [Boolean] Option :many, defined on attribute
+        #
+        # @return [void]
+        def initialize(attribute)
+          @attribute = attribute
+          @opts = attribute.batch
+          @loaders = attribute.class.serializer_class.config.batch_loaders
+          @many = attribute.many
+        end
+
+        # Returns proc that will be used to batch load registered keys values
+        # @return [#call] batch loader
+        def loader
+          @batch_loader ||= begin
+            loader = opts[:loader]
+            loader = loaders.fetch(loader) if loader.is_a?(Symbol)
+            loader
+          end
+        end
+
+        # Returns proc that will be used to find batch_key for current attribute.
+        # @return [Object] key (uid) of batch loaded object
+        def key
+          @batch_key ||= begin
+            key = opts[:key]
+
+            if key.is_a?(Symbol)
+              proc do |object|
+                handle_no_method_error { object.public_send(key) }
+              end
+            else
+              key
+            end
+          end
+        end
+
+        # Returns default value to use if batch loader does not return value for some key
+        # @return [Object] default value for missing key
+        def default_value
+          if opts.key?(:default)
+            opts[:default]
+          elsif many
+            FROZEN_EMPTY_ARRAY
+          end
+        end
+
+        private
+
+        def handle_no_method_error
+          yield
+        rescue NoMethodError => error
+          raise error, "NoMethodError when serializing '#{attribute.name}' attribute in #{attribute.class.serializer_class}\n\n#{error.message}", error.backtrace
+        end
+      end
+    end
+  end
+end

--- a/spec/serega/attribute_spec.rb
+++ b/spec/serega/attribute_spec.rb
@@ -138,14 +138,6 @@ RSpec.describe Serega::SeregaAttribute do
       expect(block.call(object)).to eq "DELEGATED_NAME"
     end
 
-    it "raises error when delegating object is nil and nil is not allowed" do
-      object = double(foo: nil)
-      delegate = {to: :foo}
-      block = attribute_class.new(name: :name, opts: {delegate: delegate}).value_block
-      expect(block).to be_a Proc
-      expect { block.call(object) }.to raise_error NoMethodError
-    end
-
     it "does not raise error when :delegating object is nil and nil is allowed" do
       object1 = double(foo: nil)
       object2 = double(foo: double(name: "NAME"))
@@ -154,6 +146,22 @@ RSpec.describe Serega::SeregaAttribute do
       expect(block).to be_a Proc
       expect(block.call(object1)).to be_nil
       expect(block.call(object2)).to eq "NAME"
+    end
+
+    it "raises error with name of serializer and serialized attribute when delegating object is nil and nil is not allowed" do
+      object = double(foo: nil)
+      delegate = {to: :foo}
+      block = attribute_class.new(name: :name, opts: {delegate: delegate}).value_block
+      expect(block).to be_a Proc
+      expect { block.call(object) }.to raise_error NoMethodError, start_with("NoMethodError when serializing 'name' attribute in #{serializer_class}")
+    end
+
+    it "raises error with name of serializer and serialized attribute when delegating method not exists on object" do
+      object = "OBJECT"
+      delegate = {to: :foo}
+      block = attribute_class.new(name: :name, opts: {delegate: delegate}).value_block
+      expect(block).to be_a Proc
+      expect { block.call(object) }.to raise_error NoMethodError, start_with("NoMethodError when serializing 'name' attribute in #{serializer_class}")
     end
   end
 

--- a/spec/serega/plugins/batch/batch_spec.rb
+++ b/spec/serega/plugins/batch/batch_spec.rb
@@ -81,67 +81,6 @@ RSpec.describe Serega::SeregaPlugins::Batch do
     end
   end
 
-  describe "BatchModel" do
-    describe "#loader" do
-      it "returns provided Proc loader" do
-        loader = proc {}
-        opts = {loader: loader}
-        model = Serega::SeregaPlugins::Batch::BatchModel.new(opts, nil, nil)
-
-        expect(model.loader).to eq loader
-      end
-
-      it "returns loader found by Symbol name" do
-        loader = proc {}
-        opts = {loader: :loader_name}
-        loaders = Serega::SeregaPlugins::Batch::BatchLoadersConfig.new(loader_name: loader)
-        model = Serega::SeregaPlugins::Batch::BatchModel.new(opts, loaders, nil)
-
-        expect(model.loader).to eq loader
-      end
-    end
-
-    describe "#key" do
-      it "returns provided Proc key" do
-        key = proc {}
-        opts = {key: key}
-        model = Serega::SeregaPlugins::Batch::BatchModel.new(opts, nil, nil)
-
-        expect(model.key).to eq key
-      end
-
-      it "constructs Proc with Symbol key" do
-        opts = {key: :some_count}
-        model = Serega::SeregaPlugins::Batch::BatchModel.new(opts, nil, nil)
-        object = double(some_count: 3)
-
-        expect(model.key.call(object)).to eq 3
-      end
-    end
-
-    describe "#default_value" do
-      it "returns nil by default" do
-        model = Serega::SeregaPlugins::Batch::BatchModel.new({}, nil, nil)
-        expect(model.default_value).to be_nil
-      end
-
-      it "returns provided default" do
-        model = Serega::SeregaPlugins::Batch::BatchModel.new({default: 0}, nil, nil)
-        expect(model.default_value).to eq 0
-      end
-
-      it "returns provided default when many=true" do
-        model = Serega::SeregaPlugins::Batch::BatchModel.new({default: 0}, nil, true)
-        expect(model.default_value).to eq 0
-      end
-
-      it "returns empty Array by default when many=true" do
-        model = Serega::SeregaPlugins::Batch::BatchModel.new({}, nil, true)
-        expect(model.default_value).to be Serega::FROZEN_EMPTY_ARRAY
-      end
-    end
-  end
-
   describe "MapPoint methods" do
     specify "#batch" do
       batch_loader = proc {}
@@ -151,7 +90,7 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       pt2 = serializer::SeregaMapPoint.new(at2, [])
 
       batch = pt1.batch
-      expect(batch).to be_a Serega::SeregaPlugins::Batch::BatchModel
+      expect(batch).to be_a Serega::SeregaPlugins::Batch::BatchOptionModel
       expect(batch.many).to be true
       expect(batch.loaders).to be serializer.config.batch_loaders
       expect(batch.key).to be_a(Proc)

--- a/spec/serega/plugins/batch/lib/batch_option_model_spec.rb
+++ b/spec/serega/plugins/batch/lib/batch_option_model_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+load_plugin_code :batch
+
+RSpec.describe Serega::SeregaPlugins::Batch::BatchOptionModel do
+  let(:serializer) { Class.new(Serega) { plugin :batch } }
+
+  describe "BatchOptionModel" do
+    describe "#loader" do
+      it "returns provided Proc loader" do
+        loader = proc {}
+        attribute = serializer.attribute :foo, batch: {loader: loader, key: :id}
+        model = described_class.new(attribute)
+
+        expect(model.loader).to eq loader
+      end
+
+      it "returns loader found by Symbol name" do
+        loader = proc {}
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :id}
+        serializer.config.batch_loaders.define(:loader_name, &loader)
+        model = described_class.new(attribute)
+
+        expect(model.loader).to eq loader
+      end
+
+      it "raises error when loader not defined" do
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :id}
+        model = described_class.new(attribute)
+
+        expect { model.loader }.to raise_error Serega::SeregaError, start_with("Batch loader with name `:loader_name` was not defined")
+      end
+    end
+
+    describe "#key" do
+      it "returns provided Proc key" do
+        key = proc {}
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: key}
+        model = described_class.new(attribute)
+
+        expect(model.key).to eq key
+      end
+
+      it "constructs Proc using key as method name" do
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :ping}
+        model = described_class.new(attribute)
+        object = double(ping: "PONG")
+
+        expect(model.key.call(object)).to eq "PONG"
+      end
+
+      it "raises error with name of serializer and attribute when object does not respond to provided key" do
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :ping}
+        model = described_class.new(attribute)
+        object = "FOO"
+
+        expect { model.key.call(object) }.to raise_error start_with("NoMethodError when serializing 'foo' attribute in #{serializer}")
+      end
+    end
+
+    describe "#default_value" do
+      it "returns nil by default" do
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :id}
+        model = described_class.new(attribute)
+
+        expect(model.default_value).to be_nil
+      end
+
+      it "returns provided default" do
+        default = 10
+        attribute = serializer.attribute :foo, batch: {loader: :loader_name, key: :id, default: default}
+        model = described_class.new(attribute)
+
+        expect(model.default_value).to eq default
+      end
+
+      it "returns empty Array by default when many=true" do
+        attribute = serializer.attribute :foo, many: true, batch: {loader: :loader_name, key: :id}
+        model = described_class.new(attribute)
+
+        expect(model.default_value).to be Serega::FROZEN_EMPTY_ARRAY
+      end
+
+      it "returns provided default when many=true" do
+        default = 10
+        attribute = serializer.attribute :foo, many: true, batch: {loader: :loader_name, key: :id, default: default}
+        model = described_class.new(attribute)
+
+        expect(model.default_value).to eq default
+      end
+    end
+  end
+end


### PR DESCRIPTION
We now show current serializer and attribute in error message to find source of error without reviewing all backtrace