### PR TITLE
Less strict attribute name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+- Less strict attribute name format. Allow attribute names to include chars "_", "-" and "~". They can be added as first or last characters also.
+- Allow to disable attribute name format check globally or per-serializer via:
+```ruby
+Serega.config.check_attribute_name = false
+
+class SomeSerializer < Serega
+  config.check_attribute_name = false
+end
+```
+
 - Added comments in code about where each methods extended
 - Allow to load :if plugin and :batch plugin in any order
 - Less objects allocations when parsing string modifiers

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ class UserSerializer < Serega
 end
 ```
 
+---
+
+⚠️ Attribute names are checked to include only "a-z", "A-Z", "0-9", "_", "-", "~" characters.
+We have this check as:
+- Attributes names can be used in URL without encoding.
+- Plugin [string_modifiers][string_modifiers] already uses "," and "()" as attribute names delimeters.
+- We are protected from errors when added some non-english character looking as english.
+
+This names check can be disabled globally or per-serializer via:
+```ruby
+Serega.config.check_attribute_name = false
+
+class SomeSerializer < Serega
+  config.check_attribute_name = false
+end
+```
+
 ### Serializing
 
 We can serialize objects using class methods `.to_h`, `.to_json`, `.as_json` and same instance methods `#to_h`, `#to_json`, `#as_json`.

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -17,6 +17,7 @@ class Serega
       initiate_keys: %i[only with except check_initiate_params].freeze,
       attribute_keys: %i[key value serializer many hide const delegate].freeze,
       serialize_keys: %i[context many].freeze,
+      check_attribute_name: true,
       check_initiate_params: true,
       max_cached_map_per_serializer_count: 0,
       to_json: (SeregaJSON.adapter == :oj) ? SeregaJSON::OjDump : SeregaJSON::JSONDump,
@@ -100,6 +101,21 @@ class Serega
       def max_cached_map_per_serializer_count=(value)
         raise SeregaError, "Must have Integer value, #{value.inspect} provided" unless value.is_a?(Integer)
         opts[:max_cached_map_per_serializer_count] = value
+      end
+
+      # Returns whether attributes names check is disabled
+      def check_attribute_name
+        opts.fetch(:check_attribute_name)
+      end
+
+      # Sets :check_attribute_name config option
+      #
+      # @param value [Boolean] Set :check_attribute_name config option
+      #
+      # @return [Boolean] New :check_attribute_name config option
+      def check_attribute_name=(value)
+        raise SeregaError, "Must have boolean value, #{value.inspect} provided" if (value != true) && (value != false)
+        opts[:check_attribute_name] = value
       end
 
       # Returns current `to_json` adapter

--- a/lib/serega/plugins/metadata/meta_attribute.rb
+++ b/lib/serega/plugins/metadata/meta_attribute.rb
@@ -60,9 +60,17 @@ class Serega
           private
 
           def check(path, opts, block)
-            CheckPath.call(path)
-            CheckOpts.call(opts, self.class.serializer_class.config.metadata.attribute_keys)
+            CheckPath.call(path) if check_attribute_name
+            CheckOpts.call(opts, attribute_keys)
             CheckBlock.call(block)
+          end
+
+          def attribute_keys
+            self.class.serializer_class.config.metadata.attribute_keys
+          end
+
+          def check_attribute_name
+            self.class.serializer_class.config.check_attribute_name
           end
         end
 

--- a/lib/serega/plugins/metadata/validations/check_path.rb
+++ b/lib/serega/plugins/metadata/validations/check_path.rb
@@ -8,16 +8,15 @@ class Serega
         # Validator for meta_attribute :path parameter
         #
         class CheckPath
-          FORMAT_ONE_CHAR = /\A[a-zA-Z0-9]\z/
-          FORMAT_MANY_CHARS = /\A[a-zA-Z0-9][a-zA-Z0-9_-]*?[a-zA-Z0-9]\z/ # allow '-' and '_' in the middle
+          # Regexp for valid path
+          FORMAT = /\A[\w~-]+\z/
 
-          private_constant :FORMAT_ONE_CHAR, :FORMAT_MANY_CHARS
+          private_constant :FORMAT
 
           class << self
             #
-            # Checks allowed characters in specified metadata path parts.
-            # Globally allowed characters: "a-z", "A-Z", "0-9".
-            # Minus and low line "-", "_" also allowed except as the first or last character.
+            # Checks allowed characters.
+            # Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~".
             #
             # @param path [Array<String, Symbol>] Metadata attribute path names
             #
@@ -33,20 +32,14 @@ class Serega
             def check_name(name)
               name = name.to_s
 
-              valid =
-                case name.size
-                when 0 then false
-                when 1 then name.match?(FORMAT_ONE_CHAR)
-                else name.match?(FORMAT_MANY_CHARS)
-                end
-
-              return if valid
-
-              raise SeregaError, message(name)
+              raise SeregaError, message(name) unless FORMAT.match?(name)
             end
 
             def message(name)
-              %(Invalid metadata path #{name.inspect}, globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
+              <<~MESSAGE.tr("\n", "")
+                Invalid metadata path #{name.inspect}.
+                 Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~"
+              MESSAGE
             end
           end
         end

--- a/lib/serega/validations/attribute/check_name.rb
+++ b/lib/serega/validations/attribute/check_name.rb
@@ -7,19 +7,13 @@ class Serega
       # Attribute `name` parameter validator
       #
       class CheckName
-        # Regexp for valid one-char attribute name
-        FORMAT_ONE_CHAR = /\A[a-zA-Z0-9]\z/
-
-        # Regexp for valid multi-chars attribute name
-        FORMAT_MANY_CHARS = /\A[a-zA-Z0-9][a-zA-Z0-9_-]*?[a-zA-Z0-9]\z/ # allow '-' and '_' in the middle
-
-        private_constant :FORMAT_ONE_CHAR, :FORMAT_MANY_CHARS
+        # Regexp for valid attribute name
+        FORMAT = /\A[\w~-]+\z/
 
         class << self
           #
           # Checks allowed characters.
-          # Globally allowed characters: "a-z", "A-Z", "0-9".
-          # Minus and low line "-", "_" also allowed except as the first or last character.
+          # Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~".
           #
           # @param name [String, Symbol] Attribute name
           #
@@ -28,23 +22,16 @@ class Serega
           #
           def call(name)
             name = SeregaUtils::SymbolName.call(name)
-
-            valid =
-              case name.size
-              when 0 then false
-              when 1 then name.match?(FORMAT_ONE_CHAR)
-              else name.match?(FORMAT_MANY_CHARS)
-              end
-
-            return if valid
-
-            raise SeregaError, message(name)
+            raise SeregaError, message(name) unless FORMAT.match?(name)
           end
 
           private
 
           def message(name)
-            %(Invalid attribute name = #{name.inspect}. Globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
+            <<~MESSAGE.tr("\n", "")
+              Invalid attribute name = #{name.inspect}.
+               Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~"
+            MESSAGE
           end
         end
       end

--- a/lib/serega/validations/check_attribute_params.rb
+++ b/lib/serega/validations/check_attribute_params.rb
@@ -41,7 +41,7 @@ class Serega
         # Validates attribute params
         #
         def validate
-          check_name
+          check_name if check_attribute_name
           check_opts
           check_block
         end
@@ -75,6 +75,10 @@ class Serega
 
         def allowed_opts_keys
           self.class.serializer_class.config.attribute_keys
+        end
+
+        def check_attribute_name
+          self.class.serializer_class.config.check_attribute_name
         end
       end
 

--- a/spec/serega/attribute_spec.rb
+++ b/spec/serega/attribute_spec.rb
@@ -174,6 +174,12 @@ RSpec.describe Serega::SeregaAttribute do
       attribute = attribute_class.new(name: :name, block: block)
       expect(attribute.value(obj, context)).to eq [3, :bar]
     end
+
+    it "works when attribute has name with `-` sign" do
+      obj = double("-foo": "-bar")
+      attribute = attribute_class.new(name: :"-foo")
+      expect(attribute.value(obj, nil)).to eq "-bar"
+    end
   end
 
   describe "#visible?" do

--- a/spec/serega/config_spec.rb
+++ b/spec/serega/config_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Serega::SeregaConfig do
     end
   end
 
+  describe "#check_attribute_name=" do
+    it "validates value is boolean" do
+      expect { config.check_attribute_name = false }.not_to raise_error
+      expect { config.check_attribute_name = true }.not_to raise_error
+      expect { config.check_attribute_name = nil }
+        .to raise_error Serega::SeregaError, "Must have boolean value, #{nil.inspect} provided"
+    end
+  end
+
   describe "#check_initiate_params=" do
     it "validates value is boolean" do
       expect { config.check_initiate_params = false }.not_to raise_error

--- a/spec/serega/plugins/metadata/metadata_spec.rb
+++ b/spec/serega/plugins/metadata/metadata_spec.rb
@@ -46,6 +46,43 @@ RSpec.describe Serega::SeregaPlugins::Metadata do
     end
   end
 
+  describe "MetaAttribute validations" do
+    subject(:validate) { serializer::MetaAttribute.new(path: ["PATH"], opts: {foo: :bar}, block: "BLOCK") }
+
+    let(:serializer) do
+      Class.new(Serega) do
+        plugin :root
+        plugin :metadata
+      end
+    end
+
+    before do
+      allow(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath).to receive(:call)
+      allow(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOpts).to receive(:call)
+      allow(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckBlock).to receive(:call)
+    end
+
+    it "validates path, opts, block" do
+      validate
+      expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath)
+        .to have_received(:call).with(["PATH"])
+
+      expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckOpts)
+        .to have_received(:call).with({foo: :bar}, [:path, :hide_nil, :hide_empty])
+
+      expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckBlock)
+        .to have_received(:call).with("BLOCK")
+    end
+
+    it "skips validating path when check_attribute_name option is false" do
+      serializer.config.check_attribute_name = false
+      validate
+
+      expect(Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath)
+        .not_to have_received(:call)
+    end
+  end
+
   describe "serialization" do
     subject(:response) { user_serializer.to_h(obj, context: context) }
 

--- a/spec/serega/plugins/metadata/validations/check_path_spec.rb
+++ b/spec/serega/plugins/metadata/validations/check_path_spec.rb
@@ -4,7 +4,7 @@ load_plugin_code(:root, :metadata)
 
 RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
   def error(name)
-    %(Invalid metadata path #{name.inspect}, globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
+    %(Invalid metadata path #{name.inspect}. Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~")
   end
 
   it "prohibits empty name" do
@@ -12,7 +12,7 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
     expect { described_class.call([:foo, ""]) }.to raise_error Serega::SeregaError, error("")
   end
 
-  it "allows one char A-Za-z0-9" do
+  it "allows one char _A-Za-z0-9~-" do
     expect { described_class.call(["a"]) }.not_to raise_error
     expect { described_class.call(["s"]) }.not_to raise_error
     expect { described_class.call(["z"]) }.not_to raise_error
@@ -22,35 +22,43 @@ RSpec.describe Serega::SeregaPlugins::Metadata::MetaAttribute::CheckPath do
     expect { described_class.call(["0"]) }.not_to raise_error
     expect { described_class.call(["5"]) }.not_to raise_error
     expect { described_class.call(["9"]) }.not_to raise_error
+    expect { described_class.call(["_"]) }.not_to raise_error
+    expect { described_class.call(["~"]) }.not_to raise_error
+    expect { described_class.call(["-"]) }.not_to raise_error
 
-    expect { described_class.call(["-"]) }.to raise_error Serega::SeregaError, error("-")
+    expect { described_class.call(["!"]) }.to raise_error Serega::SeregaError, error("!")
     expect { described_class.call(["`"]) }.to raise_error Serega::SeregaError, error("`")
-    expect { described_class.call(["_"]) }.to raise_error Serega::SeregaError, error("_")
+    expect { described_class.call(["+"]) }.to raise_error Serega::SeregaError, error("+")
+    expect { described_class.call([" "]) }.to raise_error Serega::SeregaError, error(" ")
   end
 
-  it "allows two chars A-Za-z0-9" do
+  it "allows two chars _A-Za-z0-9~-" do
     expect { described_class.call(["aZ"]) }.not_to raise_error
     expect { described_class.call(["Za"]) }.not_to raise_error
     expect { described_class.call(["09"]) }.not_to raise_error
-
-    expect { described_class.call(["a~"]) }.to raise_error Serega::SeregaError, error("a~")
-    expect { described_class.call(["a-"]) }.to raise_error Serega::SeregaError, error("a-")
-    expect { described_class.call(["-a"]) }.to raise_error Serega::SeregaError, error("-a")
-    expect { described_class.call(["_a"]) }.to raise_error Serega::SeregaError, error("_a")
-    expect { described_class.call(["a_"]) }.to raise_error Serega::SeregaError, error("a_")
+    expect { described_class.call(["_a"]) }.not_to raise_error
+    expect { described_class.call(["a_"]) }.not_to raise_error
+    expect { described_class.call(["__"]) }.not_to raise_error
+    expect { described_class.call(["a~"]) }.not_to raise_error
+    expect { described_class.call(["a-"]) }.not_to raise_error
+    expect { described_class.call(["-a"]) }.not_to raise_error
+    expect { described_class.call(["a+"]) }.to raise_error Serega::SeregaError, error("a+")
+    expect { described_class.call(["+a"]) }.to raise_error Serega::SeregaError, error("+a")
+    expect { described_class.call(["!!"]) }.to raise_error Serega::SeregaError, error("!!")
   end
 
-  it 'allows multiple chars A-Za-z0-9 with "-" and "_" in the middle' do
+  it "allows multiple chars _A-Za-z0-9~-" do
     expect { described_class.call(["foo"]) }.not_to raise_error
     expect { described_class.call(["bar"]) }.not_to raise_error
     expect { described_class.call(["fooBAR123"]) }.not_to raise_error
     expect { described_class.call(["foo-123"]) }.not_to raise_error
     expect { described_class.call(["foo_3"]) }.not_to raise_error
+    expect { described_class.call(["_-_"]) }.not_to raise_error
+    expect { described_class.call(["---"]) }.not_to raise_error
+    expect { described_class.call(["~~~"]) }.not_to raise_error
 
-    expect { described_class.call(["foo-"]) }.to raise_error Serega::SeregaError, error("foo-")
-    expect { described_class.call(["foo_"]) }.to raise_error Serega::SeregaError, error("foo_")
-    expect { described_class.call(["-foo"]) }.to raise_error Serega::SeregaError, error("-foo")
-    expect { described_class.call(["_foo"]) }.to raise_error Serega::SeregaError, error("_foo")
+    expect { described_class.call(["foo!"]) }.to raise_error Serega::SeregaError, error("foo!")
+    expect { described_class.call(["!foo"]) }.to raise_error Serega::SeregaError, error("!foo")
     expect { described_class.call(["foo+bar"]) }.to raise_error Serega::SeregaError, error("foo+bar")
   end
 end

--- a/spec/serega/validations/attribute/check_name_spec.rb
+++ b/spec/serega/validations/attribute/check_name_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
   def error(name)
-    %(Invalid attribute name = #{name.inspect}. Globally allowed characters: "a-z", "A-Z", "0-9". Minus and low line "-", "_" also allowed except as the first or last character)
+    %(Invalid attribute name = #{name.inspect}. Allowed characters: "a-z", "A-Z", "0-9", "_", "-", "~")
   end
 
   it "prohibits empty name" do
@@ -10,7 +10,7 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
     expect { described_class.call(name) }.to raise_error Serega::SeregaError, error(name)
   end
 
-  it "allows one char A-Za-z0-9" do
+  it "allows one char _A-Za-z0-9~-" do
     expect { described_class.call("a") }.not_to raise_error
     expect { described_class.call("s") }.not_to raise_error
     expect { described_class.call("z") }.not_to raise_error
@@ -20,35 +20,46 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckName do
     expect { described_class.call("0") }.not_to raise_error
     expect { described_class.call("5") }.not_to raise_error
     expect { described_class.call("9") }.not_to raise_error
+    expect { described_class.call("_") }.not_to raise_error
+    expect { described_class.call("~") }.not_to raise_error
+    expect { described_class.call("-") }.not_to raise_error
 
-    expect { described_class.call("-") }.to raise_error Serega::SeregaError, error("-")
-    expect { described_class.call("`") }.to raise_error Serega::SeregaError, error("`")
-    expect { described_class.call("_") }.to raise_error Serega::SeregaError, error("_")
+    expect { described_class.call("+") }.to raise_error Serega::SeregaError, error("+")
+    expect { described_class.call(" ") }.to raise_error Serega::SeregaError, error(" ")
+    expect { described_class.call("!") }.to raise_error Serega::SeregaError, error("!")
+    expect { described_class.call("(") }.to raise_error Serega::SeregaError, error("(")
+    expect { described_class.call(")") }.to raise_error Serega::SeregaError, error(")")
+    expect { described_class.call("[") }.to raise_error Serega::SeregaError, error("[")
+    expect { described_class.call("]") }.to raise_error Serega::SeregaError, error("]")
   end
 
-  it "allows two chars A-Za-z0-9" do
+  it "allows two chars _A-Za-z0-9~-" do
     expect { described_class.call("aZ") }.not_to raise_error
     expect { described_class.call("Za") }.not_to raise_error
     expect { described_class.call("09") }.not_to raise_error
-
-    expect { described_class.call("a~") }.to raise_error Serega::SeregaError, error("a~")
-    expect { described_class.call("a-") }.to raise_error Serega::SeregaError, error("a-")
-    expect { described_class.call("-a") }.to raise_error Serega::SeregaError, error("-a")
-    expect { described_class.call("_a") }.to raise_error Serega::SeregaError, error("_a")
-    expect { described_class.call("a_") }.to raise_error Serega::SeregaError, error("a_")
+    expect { described_class.call("_a") }.not_to raise_error
+    expect { described_class.call("a_") }.not_to raise_error
+    expect { described_class.call("__") }.not_to raise_error
+    expect { described_class.call("a~") }.not_to raise_error
+    expect { described_class.call("a-") }.not_to raise_error
+    expect { described_class.call("-a") }.not_to raise_error
+    expect { described_class.call("a+") }.to raise_error Serega::SeregaError, error("a+")
+    expect { described_class.call("+a") }.to raise_error Serega::SeregaError, error("+a")
+    expect { described_class.call("!!") }.to raise_error Serega::SeregaError, error("!!")
   end
 
-  it 'allows multiple chars A-Za-z0-9 with "-" and "_" in the middle' do
+  it "allows multiple chars _A-Za-z0-9~-" do
     expect { described_class.call("foo") }.not_to raise_error
     expect { described_class.call("bar") }.not_to raise_error
     expect { described_class.call("fooBAR123") }.not_to raise_error
     expect { described_class.call("foo-123") }.not_to raise_error
     expect { described_class.call("foo_3") }.not_to raise_error
+    expect { described_class.call("_-_") }.not_to raise_error
+    expect { described_class.call("---") }.not_to raise_error
+    expect { described_class.call("~~~") }.not_to raise_error
 
-    expect { described_class.call("foo-") }.to raise_error Serega::SeregaError, error("foo-")
-    expect { described_class.call("foo_") }.to raise_error Serega::SeregaError, error("foo_")
-    expect { described_class.call("-foo") }.to raise_error Serega::SeregaError, error("-foo")
-    expect { described_class.call("_foo") }.to raise_error Serega::SeregaError, error("_foo")
+    expect { described_class.call("foo!") }.to raise_error Serega::SeregaError, error("foo!")
+    expect { described_class.call("!foo") }.to raise_error Serega::SeregaError, error("!foo")
     expect { described_class.call("foo+bar") }.to raise_error Serega::SeregaError, error("foo+bar")
   end
 end

--- a/spec/serega/validations/check_attribute_params_spec.rb
+++ b/spec/serega/validations/check_attribute_params_spec.rb
@@ -39,4 +39,11 @@ RSpec.describe Serega::SeregaValidations::CheckAttributeParams do
     expect(Serega::SeregaValidations::Attribute::CheckOptSerializer).to have_received(:call).with(opts)
     expect(Serega::SeregaValidations::Attribute::CheckOptValue).to have_received(:call).with(opts, block)
   end
+
+  it "skips checking name if names check is disabled" do
+    serializer.config.check_attribute_name = false
+    validate
+
+    expect(Serega::SeregaValidations::Attribute::CheckName).not_to have_received(:call)
+  end
 end

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Serega do
         initiate_keys
         serialize_keys
         attribute_keys
+        check_attribute_name
         check_initiate_params
         max_cached_map_per_serializer_count
         to_json
@@ -26,6 +27,7 @@ RSpec.describe Serega do
       expect(config.serialize_keys).to match_array(%i[context many])
       expect(config.initiate_keys).to match_array(%i[only except with check_initiate_params])
       expect(config.attribute_keys).to match_array(%i[key value serializer many hide const delegate])
+      expect(config.check_attribute_name).to be true
       expect(config.check_initiate_params).to be true
       expect(config.max_cached_map_per_serializer_count).to eq 0
       expect(config.to_json.call({})).to eq "{}"


### PR DESCRIPTION
https://github.com/aglushkov/serega/issues/84

Allow attribute name to incluse "-", "_" and "~" chars, including first and last symbol.

Also added `check_attribute_name` config option that can be used to disable attribtues names validation