### PR TITLE
Fix setting :default_key option in `batch` plugin

### DIFF
--- a/lib/serega/plugins/batch/batch.rb
+++ b/lib/serega/plugins/batch/batch.rb
@@ -133,6 +133,7 @@ class Serega
         config.attribute_keys << :batch
         config.opts[:batch] = {loaders: {}, default_key: nil, auto_hide: false}
         config.batch.auto_hide = opts[:auto_hide] if opts.key?(:auto_hide)
+        config.batch.default_key = opts[:default_key] if opts.key?(:default_key)
       end
 
       #

--- a/spec/serega/plugins/batch/batch_spec.rb
+++ b/spec/serega/plugins/batch/batch_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       expect(attribute_keys).to include :batch
     end
 
-    it "adds option :auto_hide false by default" do
+    it "adds option :auto_hide (false by default)" do
       auto_hide = serializer.config.batch.auto_hide
       expect(auto_hide).to be false
     end
@@ -22,6 +22,17 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       serializer = Class.new(Serega) { plugin :batch, auto_hide: true }
       auto_hide = serializer.config.batch.auto_hide
       expect(auto_hide).to be true
+    end
+
+    it "adds option :default_key (nil by default)" do
+      default_key = serializer.config.batch.default_key
+      expect(default_key).to be_nil
+    end
+
+    it "allows to change :default_key option when defining plugin" do
+      serializer = Class.new(Serega) { plugin :batch, default_key: :id }
+      default_key = serializer.config.batch.default_key
+      expect(default_key).to eq :id
     end
   end
 


### PR DESCRIPTION
Key was not set when adding it this way:

```ruby
    plugin :batch, default_key: :id
```

It worked only with config:

```ruby
    plugin :batch
    config.batch.default_key = :id
```

Now it works either way