### PR TITLE
OpenAPI plugin changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+- Add :explicit_many_option plugin
+- Add '.openapi_properties' method to specify openapi_properties
+- Remove :openapi attribute option from :openapi plugin (replaced with openapi_properties)
+
+## [0.13.0] - 2023-07-20
+
+- Add :openapi gem that helps to construct OpenAPI schema for serializer.
+  It can help to construct response schemas and use with some OpenAPI tools
+  (for example with rswag gem). Look at README for more information
+
 ## [0.12.0] - 2023-07-10
 
 - Fix issue <https://github.com/aglushkov/serega/issues/85>

--- a/lib/serega/plugins/explicit_many_option/explicit_many_option.rb
+++ b/lib/serega/plugins/explicit_many_option/explicit_many_option.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaPlugins
+    #
+    # Plugin :explicit_many_option
+    #
+    # Plugin requires to add :many option when adding relationships
+    # (relationships are attributes with :serializer option specified)
+    #
+    # Adding this plugin makes clearer to find if relationship returns array or single object
+    #
+    # Also some plugins like :openapi load this plugin automatically as they need to know if
+    # relationship is array
+    #
+    # @example
+    #   class BaseSerializer < Serega
+    #     plugin :explicit_many_option
+    #   end
+    #
+    #   class UserSerializer < BaseSerializer
+    #     attribute :name
+    #   end
+    #
+    #   class PostSerializer < BaseSerializer
+    #     attribute :text
+    #     attribute :user, serializer: UserSerializer, many: false
+    #     attribute :comments, serializer: PostSerializer, many: true
+    #   end
+    #
+    module ExplicitManyOption
+      # @return [Symbol] Plugin name
+      def self.plugin_name
+        :explicit_many_option
+      end
+
+      #
+      # Applies plugin code to specific serializer
+      #
+      # @param serializer_class [Class<Serega>] Current serializer class
+      # @param _opts [Hash] Loaded plugins options
+      #
+      # @return [void]
+      #
+      def self.load_plugin(serializer_class, **_opts)
+        require_relative "./validations/check_opt_many"
+
+        serializer_class::CheckAttributeParams.include(CheckAttributeParamsInstanceMethods)
+      end
+
+      #
+      # Serega::SeregaValidations::CheckAttributeParams additional/patched class methods
+      #
+      # @see Serega::SeregaValidations::CheckAttributeParams
+      #
+      module CheckAttributeParamsInstanceMethods
+        private
+
+        def check_opts
+          super
+
+          CheckOptMany.call(opts)
+        end
+      end
+    end
+
+    register_plugin(ExplicitManyOption.plugin_name, ExplicitManyOption)
+  end
+end

--- a/lib/serega/plugins/explicit_many_option/validations/check_opt_many.rb
+++ b/lib/serega/plugins/explicit_many_option/validations/check_opt_many.rb
@@ -2,7 +2,7 @@
 
 class Serega
   module SeregaPlugins
-    module OpenAPI
+    module ExplicitManyOption
       #
       # Validator for attribute :many option
       #
@@ -26,8 +26,7 @@ class Serega
 
             raise SeregaError,
               "Attribute option :many [Boolean] must be provided" \
-              " for attributes with :serializer option" \
-              " when :openapi plugin added"
+              " for attributes with :serializer option"
           end
         end
       end

--- a/lib/serega/plugins/openapi/lib/modules/config.rb
+++ b/lib/serega/plugins/openapi/lib/modules/config.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaPlugins
+    module OpenAPI
+      #
+      # Config class additional/patched instance methods
+      #
+      # @see Serega::SeregaConfig
+      #
+      module ConfigInstanceMethods
+        #
+        # Returns openapi plugin config
+        #
+        # @return [Serega::SeregaPlugins::OpenAPI::OpenAPIConfig] configuration for openapi plugin
+        #
+        def openapi
+          @openapi ||= OpenAPIConfig.new(self.class.serializer_class, opts.fetch(:openapi))
+        end
+      end
+    end
+  end
+end

--- a/lib/serega/plugins/openapi/lib/openapi_config.rb
+++ b/lib/serega/plugins/openapi/lib/openapi_config.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaPlugins
+    module OpenAPI
+      #
+      # OpenAPI plugin config
+      #
+      class OpenAPIConfig
+        attr_reader :serializer_class, :opts
+
+        def initialize(serializer_class, opts)
+          @serializer_class = serializer_class
+          @opts = opts
+        end
+
+        #
+        # Saves new properties
+        #
+        # @param new_properties [Hash] new properties
+        #
+        # @return [Hash] OpenAPI properties
+        #
+        def properties(new_properties = FROZEN_EMPTY_HASH)
+          properties = opts[:properties]
+          return properties if new_properties.empty?
+
+          new_properties = SeregaUtils::EnumDeepDup.call(new_properties)
+          symbolize_keys!(new_properties)
+
+          new_properties.each do |attribute_name, new_attribute_properties|
+            check_attribute_exists(attribute_name)
+            check_properties_is_a_hash(attribute_name, new_attribute_properties)
+
+            properties[attribute_name] = symbolize_keys!(new_attribute_properties)
+          end
+        end
+
+        #
+        # @return [#call] builder of `$ref` attribute
+        #
+        def ref_builder
+          opts[:ref_builder]
+        end
+
+        #
+        # Sets new $ref option builder
+        #
+        # @param builder [#call] Callable object that accepts serializer_class and constructs $ref option string
+        #
+        # @return Specified new builder
+        #
+        def ref_builder=(builder)
+          raise SeregaError, "ref_builder must respond to #call" unless builder.respond_to?(:call)
+          opts[:ref_builder] = builder
+        end
+
+        #
+        # @return [#call] builder of schema name
+        #
+        def schema_name_builder
+          opts[:schema_name_builder]
+        end
+
+        #
+        # Sets new schema_name_builder
+        #
+        # @param builder [#call] Callable object that accepts serializer_class and
+        #   constructs schema name to use in schemas list and in $ref option
+        #
+        # @return Specified new builder
+        #
+        def schema_name_builder=(builder)
+          raise SeregaError, "schema_name_builder must respond to #call" unless builder.respond_to?(:call)
+          opts[:schema_name_builder] = builder
+        end
+
+        private
+
+        def check_attribute_exists(attribute_name)
+          return if serializer_class.attributes.key?(attribute_name)
+
+          raise SeregaError, "No attribute with name :#{attribute_name}"
+        end
+
+        def check_properties_is_a_hash(attribute_name, new_attribute_properties)
+          return if new_attribute_properties.is_a?(Hash)
+
+          raise SeregaError, "Property #{attribute_name} value must be a Hash," \
+            " but #{new_attribute_properties.inspect} was provided"
+        end
+
+        def symbolize_keys!(opts)
+          opts.transform_keys! do |key|
+            key.to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/serega/plugins/openapi/openapi.rb
+++ b/lib/serega/plugins/openapi/openapi.rb
@@ -16,10 +16,8 @@ class Serega
     def self.schemas(serializers = self.serializers)
       serializers.each_with_object({}) do |serializer_class, schemas|
         schema = serializer_class.openapi_schema
-        next if schema.empty?
-
-        id = serializer_class.openapi_schema_name
-        schemas[id] = schema
+        schema_name = serializer_class.openapi_schema_name
+        schemas[schema_name] = schema
       end
     end
 
@@ -40,20 +38,26 @@ class Serega
     # This schemas can be easielty used with "rswag" gem by adding them to "config.swagger_docs"
     #   https://github.com/rswag/rswag#referenced-parameters-and-schema-definitions
     #
-    # OpenAPI properties will have no any "type" or other limits specified by default,
-    # you should provide them as attribute :openapi option.
-    #
     # This plugin only adds type "object" or "array" for relationships and marks
     # attributes as **required** if they have no :hide option set.
     #
+    # OpenAPI properties will have no any "type" or other options specified by default,
+    # you should provide them in 'YourSerializer.openapi_properties' method.
+    # `openapi_properties` can be specified multiple time, in this case they wil be merged.
+    #
     # After enabling this plugin attributes with :serializer option will have
-    # to have :many option set to construct "object" or "array" openapi type.
+    # to have :many option set to construct "object" or "array" openapi type for relationships.
     #
-    # Example constructing all serializers schemas: "Serega::OpenAPI.schemas"
+    # OpenAPI `$ref` property will be added automatically for all relationships.
     #
-    # Example constructing specific serializers schemas: "Serega::OpenAPI.schemas(serializers_classes_array)"
+    # Example constructing all serializers schemas:
+    #   `Serega::OpenAPI.schemas`
     #
-    # Example constructing one serializer schema: "SomeSerializer.openapi_schema"
+    # Example constructing specific serializers schemas:
+    #   `Serega::OpenAPI.schemas(Serega::OpenAPI.serializers - [MyBaseSerializer])`
+    #
+    # Example constructing one serializer schema:
+    #   `SomeSerializer.openapi_schema`
     #
     # @example
     #   class BaseSerializer < Serega
@@ -61,13 +65,23 @@ class Serega
     #   end
     #
     #   class UserSerializer < BaseSerializer
-    #     attribute :name, openapi: { type: "string" }
+    #     attribute :name
+    #
+    #     openapi_properties(
+    #       name: { type: :string }
+    #     )
     #   end
     #
     #   class PostSerializer < BaseSerializer
-    #     attribute :text, openapi: { type: "string" }
+    #     attribute :text
     #     attribute :user, serializer: UserSerializer, many: false
     #     attribute :comments, serializer: PostSerializer, many: true, hide: true
+    #
+    #     openapi_properties(
+    #       text: { type: :string },
+    #       user: { type: 'object' }, # `$ref` option will be added automatically when constructing schema
+    #       comments: { type: 'array' } # `items` option with `$ref` will be added automatically when constructing schema
+    #     )
     #   end
     #
     #   puts Serega::OpenAPI.schemas
@@ -94,9 +108,25 @@ class Serega
     #   }
     #
     module OpenAPI
+      DEFAULT_SCHEMA_NAME_BUILDER = ->(serializer_class) { serializer_class.name }
+      DEFAULT_REF_BUILDER = ->(serializer_class) { "#/components/schemas/#{serializer_class.openapi_schema_name}" }
+
       # @return [Symbol] Plugin name
       def self.plugin_name
         :openapi
+      end
+
+      # Checks requirements and loads additional plugins
+      #
+      # @param serializer_class [Class<Serega>] Current serializer class
+      # @param opts [Hash] loaded plugins opts
+      #
+      # @return [void]
+      #
+      def self.before_load_plugin(serializer_class, **opts)
+        unless serializer_class.plugin_used?(:explicit_many_option)
+          serializer_class.plugin :explicit_many_option
+        end
       end
 
       #
@@ -107,12 +137,18 @@ class Serega
       #
       # @return [void]
       #
-      def self.load_plugin(serializer_class, **_opts)
-        require_relative "./validations/check_opt_many"
+      def self.load_plugin(serializer_class, **opts)
+        require_relative "./lib/modules/config"
+        require_relative "./lib/openapi_config"
 
         serializer_class.extend(ClassMethods)
-        serializer_class::SeregaAttribute.include(AttributeInstanceMethods)
-        serializer_class::CheckAttributeParams.include(CheckAttributeParamsInstanceMethods)
+        serializer_class::SeregaConfig.include(ConfigInstanceMethods)
+
+        config = serializer_class.config
+        config.opts[:openapi] = {properties: {}}
+        openapi_config = serializer_class.config.openapi
+        openapi_config.schema_name_builder = opts[:schema_name_builder] || DEFAULT_SCHEMA_NAME_BUILDER
+        openapi_config.ref_builder = opts[:ref_builder] || DEFAULT_REF_BUILDER
       end
 
       #
@@ -124,10 +160,7 @@ class Serega
       # @return [void]
       #
       def self.after_load_plugin(serializer_class, **opts)
-        Serega::OpenAPI.serializers << serializer_class
-
-        config = serializer_class.config
-        config.attribute_keys << :openapi
+        Serega::OpenAPI.serializers << serializer_class unless serializer_class.equal?(Serega)
       end
 
       #
@@ -140,14 +173,12 @@ class Serega
         # OpenAPI schema for current serializer
         #
         def openapi_schema
-          return FROZEN_EMPTY_HASH if attributes.empty?
-
-          properties = {}
+          properties = SeregaUtils::EnumDeepDup.call(openapi_properties)
           required_properties = []
 
           attributes.each do |attribute_name, attribute|
-            properties[attribute_name] = attribute.openapi_opts
-            required_properties << attribute_name unless attribute.hide
+            add_openapi_property(properties, attribute_name, attribute)
+            add_openapi_required_property(required_properties, attribute_name, attribute)
           end
 
           {
@@ -159,11 +190,23 @@ class Serega
         end
 
         #
-        # Name of openapi schema for current serializer.
-        #   It will be used also in $ref links to this schema
+        # Adds new OpenAPI properties and returns all properties
+        #
+        # @param props [Hash] Specifies new properties
+        #
+        # @return [Hash] Specified OpenAPI properties
+        #
+        def openapi_properties(props = FROZEN_EMPTY_HASH)
+          config.openapi.properties(props)
+        end
+
+        #
+        # Builds OpenAPI schema name using configured builder
+        #
+        # @return [String] OpenAPI schema name
         #
         def openapi_schema_name
-          name
+          config.openapi.schema_name_builder.call(self)
         end
 
         private
@@ -172,39 +215,24 @@ class Serega
           super
           Serega::OpenAPI.serializers << subclass
         end
-      end
 
-      #
-      # Serega::SeregaAttribute additional/patched instance methods
-      #
-      # @see Serega::SeregaAttribute::AttributeInstanceMethods
-      #
-      module AttributeInstanceMethods
-        #
-        # Options for openapi schema property
-        #
-        def openapi_opts
-          opts = initials[:opts][:openapi]
-          return opts unless opts.nil? # return custom opts if provided (including false value)
-          return FROZEN_EMPTY_HASH if !relation?
+        def add_openapi_property(properties, attribute_name, attribute)
+          property = properties[attribute_name] ||= {}
+          return unless attribute.relation?
 
-          ref = "#/components/schemas/#{serializer.openapi_schema_name}"
-          many ? {type: "array", items: {"$ref": ref}} : {"$ref": ref}
+          ref = attribute.serializer.config.openapi.ref_builder.call(attribute.serializer)
+
+          if attribute.many
+            property[:type] = "array"
+            property[:items] ||= {}
+            property[:items][:$ref] ||= ref
+          else
+            property[:$ref] ||= ref
+          end
         end
-      end
 
-      #
-      # Serega::SeregaValidations::CheckAttributeParams additional/patched class methods
-      #
-      # @see Serega::SeregaValidations::CheckAttributeParams
-      #
-      module CheckAttributeParamsInstanceMethods
-        private
-
-        def check_opts
-          super
-
-          CheckOptMany.call(opts)
+        def add_openapi_required_property(required_properties, attribute_name, attribute)
+          required_properties << attribute_name unless attribute.hide
         end
       end
     end

--- a/spec/serega/plugins/explicit_many_option/explicit_many_option_spec.rb
+++ b/spec/serega/plugins/explicit_many_option/explicit_many_option_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+load_plugin_code :explicit_many_option
+
+RSpec.describe Serega::SeregaPlugins::ExplicitManyOption do
+  let(:base_serializer) do
+    Class.new(Serega) do
+      plugin :explicit_many_option
+    end
+  end
+
+  describe "Validations" do
+    describe "CheckMany" do
+      it "require to set :many option for attributes with serializer" do
+        expect { base_serializer.attribute :foo, serializer: base_serializer }
+          .to raise_error Serega::SeregaError,
+            "Attribute option :many [Boolean] must be provided" \
+            " for attributes with :serializer option"
+      end
+    end
+  end
+end

--- a/spec/serega/plugins/openapi/openapi_spec.rb
+++ b/spec/serega/plugins/openapi/openapi_spec.rb
@@ -9,60 +9,162 @@ RSpec.describe Serega::SeregaPlugins::OpenAPI do
     end
   end
 
-  describe "AttributeMethods" do
-    describe "#openapi_opts" do
-      it "returns provided property if it is not null" do
-        attribute = base_serializer.attribute :foo, openapi: {type: "string"}
-        expect(attribute.openapi_opts).to eq({type: "string"})
+  describe "loading" do
+    it "loads additionally :explicit_many_option plugin" do
+      expect(base_serializer.plugin_used?(:explicit_many_option)).to be true
+    end
+
+    it "works when :explicit_many_option plugin is already loaded" do
+      expect {
+        Class.new(Serega) do
+          plugin :explicit_many_option
+          plugin :openapi
+        end
+      }.not_to raise_error
+    end
+
+    it "adds serializer to OpenAPI serializers list" do
+      Serega::OpenAPI.serializers.clear
+      base_serializer
+      expect(Serega::OpenAPI.serializers).to eq [base_serializer]
+    end
+
+    it "does not add Serega main class OpenAPI serializers list" do
+      Serega::OpenAPI.serializers.clear
+
+      # Overwrite equality check to not load plugin to Serega, as it will broke other tests
+      #   Serega.plugin :openapi
+      Class.new(Serega) do
+        def self.equal?(other)
+          other == Serega
+        end
+
+        plugin :openapi
       end
 
-      it "returns empty hash if provided null" do
-        attribute_foo = base_serializer.attribute :foo
-        attribute_bar = base_serializer.attribute :bar, openapi: nil
-        expect(attribute_foo.openapi_opts).to eq({})
-        expect(attribute_bar.openapi_opts).to eq({})
-      end
+      expect(Serega::OpenAPI.serializers).to eq []
+    end
+  end
 
-      it "returns $rel attribute for relation with many: false option" do
-        user_serializer = Class.new(base_serializer)
-        allow(user_serializer).to receive(:openapi_schema_name).and_return("user")
-        attribute = base_serializer.attribute :foo, serializer: user_serializer, many: false
-        expect(attribute.openapi_opts).to eq({:$ref => "#/components/schemas/user"})
-      end
+  describe "configuration" do
+    it "configures default schema_name builder" do
+      expect(base_serializer.config.openapi.schema_name_builder).to eq described_class::DEFAULT_SCHEMA_NAME_BUILDER
+    end
 
-      it "returns type=\"array\" for relation with many: true option" do
-        user_serializer = Class.new(base_serializer)
-        allow(user_serializer).to receive(:openapi_schema_name).and_return("user")
-        attribute = base_serializer.attribute :foo, serializer: user_serializer, many: true
-        expect(attribute.openapi_opts).to eq(type: "array", items: {:$ref => "#/components/schemas/user"})
+    it "configures default $ref option builder" do
+      expect(base_serializer.config.openapi.ref_builder).to eq described_class::DEFAULT_REF_BUILDER
+    end
+
+    it "allows to configure to schema_name_builder when loading plugin" do
+      builder = proc {}
+      serializer = Class.new(Serega) { plugin :openapi, schema_name_builder: builder }
+      expect(serializer.config.openapi.schema_name_builder).to equal builder
+    end
+
+    it "allows to configure to $ref option builder when loading plugin" do
+      builder = proc {}
+      serializer = Class.new(Serega) { plugin :openapi, ref_builder: builder }
+      expect(serializer.config.openapi.ref_builder).to equal builder
+    end
+
+    it "raises error when not callable value is set as schema_name_builder" do
+      expect { Class.new(Serega) { plugin :openapi, schema_name_builder: "" } }
+        .to raise_error Serega::SeregaError, "schema_name_builder must respond to #call"
+    end
+
+    it "raises error when not callable value is set as ref_builder" do
+      expect { Class.new(Serega) { plugin :openapi, ref_builder: "" } }
+        .to raise_error Serega::SeregaError, "ref_builder must respond to #call"
+    end
+  end
+
+  describe "ConfigMethods" do
+    describe "#openapi" do
+      it "returns OpenAPIConfig object" do
+        expect(base_serializer.config.openapi).to be_a described_class::OpenAPIConfig
       end
     end
   end
 
-  describe "Validations" do
-    describe "CheckMany" do
-      it "require to set :many option for attributes with serializer" do
-        expect { base_serializer.attribute :foo, serializer: base_serializer }
-          .to raise_error Serega::SeregaError,
-            "Attribute option :many [Boolean] must be provided" \
-            " for attributes with :serializer option" \
-            " when :openapi plugin added"
+  describe described_class::OpenAPIConfig do
+    let(:serializer) do
+      Class.new(base_serializer) do
+        attribute :attr1
+        attribute :attr2
+      end
+    end
+
+    let(:config) { serializer.config.openapi }
+
+    describe "#properties" do
+      it "returns current properties" do
+        expect(config.properties).to eq({})
+      end
+
+      it "saves properties" do
+        config.properties(attr1: {type: "string"})
+        expect(config.properties).to eq(attr1: {type: "string"})
+      end
+
+      it "saves properties with simbolized keys" do
+        config.properties("attr1" => {"type" => "string"})
+        expect(config.properties).to eq(attr1: {type: "string"})
+      end
+
+      it "merges properties" do
+        config.properties(attr1: {type: "string"})
+        config.properties(attr2: {type: "integer"})
+
+        expect(config.properties).to eq(
+          attr1: {type: "string"},
+          attr2: {type: "integer"}
+        )
+      end
+
+      it "raises error if no attribute with defined property" do
+        expect { config.properties(foobar: {}) }
+          .to raise_error Serega::SeregaError, "No attribute with name :foobar"
+      end
+
+      it "raises error property value is not a Hash" do
+        expect { config.properties(attr1: "string") }
+          .to raise_error Serega::SeregaError, "Property attr1 value must be a Hash, but \"string\" was provided"
       end
     end
   end
 
   describe "ClassMethods" do
+    describe ".inherited" do
+      it "saves serializer to list of OpenAPI serializers except Serega main class" do
+        Serega::OpenAPI.serializers.clear
+
+        base_serializer
+        expect(Serega::OpenAPI.serializers).to eq [base_serializer]
+
+        new_serializer = Class.new(base_serializer)
+        expect(Serega::OpenAPI.serializers).to eq [base_serializer, new_serializer]
+      end
+    end
+
     describe ".openapi_schema" do
-      it "returns schema for serializer" do
+      it "returns empty object schema for serializer without attributes" do
+        user_serializer = Class.new(base_serializer)
+        expect(user_serializer.openapi_schema).to eq(
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false
+        )
+      end
+
+      it "returns required property for not hidden attribute" do
         user_serializer = Class.new(base_serializer) do
           attribute :name
         end
 
-        expect(user_serializer.openapi_schema).to eq(
-          type: "object",
+        expect(user_serializer.openapi_schema).to include(
           properties: {name: {}},
-          required: [:name],
-          additionalProperties: false
+          required: [:name]
         )
       end
 
@@ -77,15 +179,49 @@ RSpec.describe Serega::SeregaPlugins::OpenAPI do
         )
       end
 
-      it "returns empty hash schema for serializer without attributes" do
-        user_serializer = Class.new(base_serializer)
+      it "returns options set in openapi_properties" do
+        user_serializer = Class.new(base_serializer) do
+          attribute :name
 
-        expect(user_serializer.openapi_schema).to eq({})
+          openapi_properties(
+            name: {type: :string}
+          )
+        end
+
+        expect(user_serializer.openapi_schema).to include(
+          properties: {name: {type: :string}}
+        )
+      end
+
+      it "returns $ref for relationship with many: false" do
+        child_serializer = Class.new(base_serializer)
+        child_serializer.config.openapi.ref_builder = proc { "ref" }
+
+        user_serializer = Class.new(base_serializer) do
+          attribute :child, serializer: child_serializer, many: false
+        end
+
+        expect(user_serializer.openapi_schema).to include(
+          properties: {child: {"$ref": "ref"}}
+        )
+      end
+
+      it "returns type=array and items with $ref for relationship with many: true" do
+        child_serializer = Class.new(base_serializer)
+        child_serializer.config.openapi.ref_builder = proc { "ref" }
+
+        user_serializer = Class.new(base_serializer) do
+          attribute :children, serializer: child_serializer, many: true
+        end
+
+        expect(user_serializer.openapi_schema).to include(
+          properties: {children: {type: "array", items: {"$ref": "ref"}}}
+        )
       end
     end
 
     describe ".openapi_schema_name" do
-      it "returns serializer name" do
+      it "returns serializer name by default" do
         user_serializer = Class.new(base_serializer) do
           def self.name
             "API::UserSerializer"
@@ -109,19 +245,28 @@ RSpec.describe Serega::SeregaPlugins::OpenAPI do
         users = user_serializer
 
         Class.new(base_serializer) do
-          attribute :title, openapi: {type: "string"}
+          attribute :title
           attribute :user, serializer: users, many: false
+
+          openapi_properties(title: {type: "string"})
         end
       end
 
       before do
         described_class.serializers.clear
-        allow(user_serializer).to receive(:openapi_schema_name).and_return("users")
-        allow(post_serializer).to receive(:openapi_schema_name).and_return("posts")
+        allow(base_serializer).to receive(:name).and_return("base")
+        allow(user_serializer).to receive(:name).and_return("users")
+        allow(post_serializer).to receive(:name).and_return("posts")
       end
 
       it "returns schemas for all serializers" do
         expect(described_class.schemas).to eq(
+          "base" => {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: false
+          },
           "posts" => {
             type: "object",
             properties: {title: {type: "string"}, user: {:$ref => "#/components/schemas/users"}},
@@ -135,6 +280,13 @@ RSpec.describe Serega::SeregaPlugins::OpenAPI do
             additionalProperties: false
           }
         )
+      end
+
+      it "returns schemas for provided serializers" do
+        schemas = described_class.schemas(described_class.serializers - [base_serializer])
+        expect(schemas.length).to eq 2
+        expect(schemas).to include("posts")
+        expect(schemas).to include("users")
       end
     end
 


### PR DESCRIPTION
- Add :explicit_many_option plugin
- Add '.openapi_properties' method to specify openapi_properties
- Remove :openapi attribute option from :openapi plugin (replaced with openapi_properties)