### PR TITLE
Validate extra keys for attribute delegate options

### DIFF
--- a/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
+++ b/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
@@ -23,7 +23,7 @@ class Serega
             SeregaValidations::Utils::CheckOptIsHash.call(opts, :batch)
 
             batch = opts[:batch]
-            SeregaValidations::Utils::CheckAllowedKeys.call(batch, %i[key loader default])
+            SeregaValidations::Utils::CheckAllowedKeys.call(batch, %i[key loader default], :batch)
 
             check_batch_opt_key(batch, serializer_class)
             check_batch_opt_loader(batch)

--- a/lib/serega/validations/attribute/check_opt_delegate.rb
+++ b/lib/serega/validations/attribute/check_opt_delegate.rb
@@ -34,6 +34,7 @@ class Serega
             check_opt_delegate_to(delegate_opts)
             check_opt_delegate_method(delegate_opts)
             check_opt_delegate_allow_nil(delegate_opts)
+            check_opt_delegate_extra_opts(delegate_opts)
           end
 
           def check_opt_delegate_to(delegate_opts)
@@ -49,6 +50,10 @@ class Serega
 
           def check_opt_delegate_allow_nil(delegate_opts)
             Utils::CheckOptIsBool.call(delegate_opts, :allow_nil)
+          end
+
+          def check_opt_delegate_extra_opts(delegate_opts)
+            Utils::CheckAllowedKeys.call(delegate_opts, %i[to method allow_nil], :delegate)
           end
 
           def check_usage_with_other_params(opts, block)

--- a/lib/serega/validations/check_attribute_params.rb
+++ b/lib/serega/validations/check_attribute_params.rb
@@ -58,7 +58,7 @@ class Serega
         # - plugin :if (checks :if, :if_value, :unless, :unless_value options)
         # - plugin :preloads (checks :preload option)
         def check_opts
-          Utils::CheckAllowedKeys.call(opts, allowed_opts_keys)
+          Utils::CheckAllowedKeys.call(opts, allowed_opts_keys, :attribute)
 
           Attribute::CheckOptConst.call(opts, block)
           Attribute::CheckOptDelegate.call(opts, block)

--- a/lib/serega/validations/check_initiate_params.rb
+++ b/lib/serega/validations/check_initiate_params.rb
@@ -35,7 +35,7 @@ class Serega
         private
 
         def check_allowed_keys
-          Utils::CheckAllowedKeys.call(opts, serializer_class.config.initiate_keys)
+          Utils::CheckAllowedKeys.call(opts, serializer_class.config.initiate_keys, :initiate)
         end
 
         def check_modifiers

--- a/lib/serega/validations/check_serialize_params.rb
+++ b/lib/serega/validations/check_serialize_params.rb
@@ -33,7 +33,7 @@ class Serega
         private
 
         def check_opts
-          Utils::CheckAllowedKeys.call(opts, serializer_class.config.serialize_keys)
+          Utils::CheckAllowedKeys.call(opts, serializer_class.config.serialize_keys, :serialize)
 
           Utils::CheckOptIsHash.call(opts, :context)
           Utils::CheckOptIsBool.call(opts, :many)

--- a/lib/serega/validations/utils/check_allowed_keys.rb
+++ b/lib/serega/validations/utils/check_allowed_keys.rb
@@ -18,11 +18,13 @@ class Serega
         # @raise [Serega::SeregaError] error when any hash key is not allowed
         #
         # @return [void]
-        def self.call(opts, allowed_keys)
+        def self.call(opts, allowed_keys, parameter_name)
           opts.each_key do |key|
             next if allowed_keys.include?(key)
 
-            raise SeregaError, "Invalid option #{key.inspect}. Allowed options are: #{allowed_keys.map(&:inspect).join(", ")}"
+            raise SeregaError,
+              "Invalid #{parameter_name} option #{key.inspect}." \
+              " Allowed options are: #{allowed_keys.map(&:inspect).sort.join(", ")}"
           end
         end
       end

--- a/spec/serega/validations/attribute/check_opt_delegate_spec.rb
+++ b/spec/serega/validations/attribute/check_opt_delegate_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Serega::SeregaValidations::Attribute::CheckOptDelegate do
       .to raise_error Serega::SeregaError, "Invalid option :method => 123. Must be a String or a Symbol"
   end
 
+  it "checks has no extra options" do
+    allow(Serega::SeregaValidations::Utils::CheckAllowedKeys).to receive(:call)
+
+    described_class.call(delegate: {to: :foo})
+    expect(Serega::SeregaValidations::Utils::CheckAllowedKeys)
+      .to have_received(:call)
+      .with({to: :foo}, %i[to method allow_nil], :delegate)
+  end
+
   it "prohibits to use with :method opt" do
     expect { described_class.call(delegate: {to: :foo}, method: :bar) }
       .to raise_error Serega::SeregaError, "Option :delegate can not be used together with option :method"

--- a/spec/serega/validations/check_attribute_params_spec.rb
+++ b/spec/serega/validations/check_attribute_params_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Serega::SeregaValidations::CheckAttributeParams do
 
   it "checks valid keys" do
     validate
-    expect(Serega::SeregaValidations::Utils::CheckAllowedKeys).to have_received(:call).with(opts, serializer.config.attribute_keys)
+
+    expect(Serega::SeregaValidations::Utils::CheckAllowedKeys)
+      .to have_received(:call).with(opts, serializer.config.attribute_keys, :attribute)
   end
 
   it "checks each option value" do

--- a/spec/serega/validations/check_initiate_params_spec.rb
+++ b/spec/serega/validations/check_initiate_params_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe Serega::SeregaValidations::CheckInitiateParams do
     validate
 
     expect(Serega::SeregaValidations::Utils::CheckAllowedKeys)
-      .to have_received(:call).with(opts, serializer.config.initiate_keys)
+      .to have_received(:call).with(opts, serializer.config.initiate_keys, :initiate)
 
-    expect(check_modifiers).to have_received(:call).with(serializer, {foo: {}}, {bazz: {}}, {bar: {}})
+    expect(check_modifiers)
+      .to have_received(:call)
+      .with(serializer, {foo: {}}, {bazz: {}}, {bar: {}})
   end
 end

--- a/spec/serega/validations/check_serialize_params_spec.rb
+++ b/spec/serega/validations/check_serialize_params_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Serega::SeregaValidations::CheckSerializeParams do
 
   it "checks valid keys" do
     validate
-    expect(Serega::SeregaValidations::Utils::CheckAllowedKeys).to have_received(:call).with(opts, serializer.config.serialize_keys)
+    expect(Serega::SeregaValidations::Utils::CheckAllowedKeys).to have_received(:call).with(opts, serializer.config.serialize_keys, :serialize)
     expect(Serega::SeregaValidations::Utils::CheckOptIsHash).to have_received(:call).with(opts, :context)
     expect(Serega::SeregaValidations::Utils::CheckOptIsBool).to have_received(:call).with(opts, :many)
   end

--- a/spec/serega/validations/utils/check_allowed_keys_spec.rb
+++ b/spec/serega/validations/utils/check_allowed_keys_spec.rb
@@ -4,14 +4,11 @@ RSpec.describe Serega::SeregaValidations::Utils::CheckAllowedKeys do
   let(:opts) { {opt1: :foo, opt2: :bar} }
   let(:attribute_keys) { %i[opt1 opt2] }
 
-  def invalid_key_error(key, attribute_keys)
-    "Invalid option #{key.inspect}. Allowed options are: #{attribute_keys.map(&:inspect).join(", ")}"
-  end
-
   it "checks valid keys" do
-    expect { described_class.call(opts, attribute_keys) }.not_to raise_error
+    expect { described_class.call(opts, attribute_keys, :param) }.not_to raise_error
 
-    expect { described_class.call(opts, %i[opt1]) }
-      .to raise_error Serega::SeregaError, invalid_key_error(:opt2, %i[opt1])
+    expect { described_class.call(opts, %i[opt1 opt5 opt4], :PARAM_NAME) }
+      .to raise_error Serega::SeregaError,
+        "Invalid PARAM_NAME option :opt2. Allowed options are: :opt1, :opt4, :opt5"
   end
 end


### PR DESCRIPTION
Improve message about extra keys for all cases

- show name where options belongs to
- sort allowed values