### PR TITLE
Require to define batch loaders before assigning to attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+- Require named batch loaders to be predefined before usage
+
+```ruby
+class AppSerializer < Serega
+  plugin :batch
+
+  # Define named loader first
+  config.batch.define(:posts_comments_counter) do |post_ids|
+    Comment.where(post_id: post_ids).group(:post_id).count
+  end
+end
+
+class PostSerializer < AppSerializer
+  # Use it later
+  attribute :comments_count,
+    batch: { loader: :posts_comments_counter, key: :id }
+end
+```
+
 ## [0.17.0] - 2023-11-03
 
 - Allow to provide callable/lambdas objects with 0-2 args as attribute :value

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -29,7 +29,7 @@ class Serega
       #
       # @param object [Object] Serialized object
       #
-      # @return [Hash, Array<Hash>] Serialized object(s)
+      # @return [Hash, Array<Hash>, nil] Serialized object(s)
       def serialize(object)
         return if object.nil?
 

--- a/lib/serega/plugins/batch/batch.rb
+++ b/lib/serega/plugins/batch/batch.rb
@@ -5,62 +5,19 @@ class Serega
     #
     # Plugin `:batch`
     #
-    # Adds ability to load nested attributes values in batches.
+    # Must be used to omit N+1 when loading attributes values.
     #
-    # It can be used to find value for attributes in optimal way:
-    # - load associations for multiple objects
-    # - load counters for multiple objects
-    # - make any heavy calculations for multiple objects only once
+    # @example Quick example
     #
-    # After including plugin, attributes gain new `:batch` option.
+    #   class AppSerializer
+    #     plugin :batch, key: :id
+    #   end
     #
-    # `:batch` option must be a hash with this keys:
-    # - `key` (required) [Symbol, Proc, callable] - Defines current object identifier.
-    #   Later `loader` will accept array of `keys` to find `values`.
-    # - `loader` (required) [Symbol, Proc, callable] - Defines how to fetch values for
-    #   batch of keys. Receives 3 parameters: keys, context, plan_point.
-    # - `default` (optional) - Default value for attribute.
-    #   By default it is `nil` or `[]` when attribute has option `many: true`
-    #
-    # If `:loader` was defined using name (as Symbol) then batch loader must be
-    # defined in serializer config: `config.batch.define(:loader_name) { ... }` method.
-    #
-    # *Result of this `:loader` callable must be a **Hash** where*:
-    # - keys - provided keys
-    # - values - values for according keys
-    #
-    # `Batch` plugin can be defined with two specific attributes:
-    # - `auto_hide: true` - Marks attributes with defined :batch as hidden, so it
-    #   will not be serialized by default
-    # - `default_key: :id` - Set default object key (in this case :id) that will be used for all attributes with :batch option specified.
-    #
-    # This options (`auto_hide`, `default_key`) also can be set as config options in
-    # any nested serializer.
-    #
-    # @example
-    #   class PostSerializer < Serega
-    #     plugin :batch, auto_hide: true, default_key: :id
-    #
-    #     # Define batch loader via callable class, it must accept three args (keys, context, plan_point)
-    #     attribute :comments_count, batch: { loader: PostCommentsCountBatchLoader, default: 0}
-    #
-    #     # Define batch loader via Symbol, later we should define this loader via config.batch.define(:posts_comments_counter) { ... }
-    #     attribute :comments_count, batch: { loader: :posts_comments_counter, default: 0}
-    #
-    #     # Define batch loader with serializer
-    #     attribute :comments, serializer: CommentSerializer, batch: { loader: :posts_comments, default: []}
-    #
-    #     # Resulted block must return hash like { key => value(s) }
-    #     config.batch.define(:posts_comments_counter) do |keys|
-    #       Comment.group(:post_id).where(post_id: keys).count
-    #     end
-    #
-    #     # We can return objects that will be automatically serialized if attribute defined with :serializer
-    #     # Parameter `context` can be used when loading batch
-    #     # Parameter `plan_point` can be used to find nested attributes that will be serialized (`plan_point.preloads`)
-    #     config.batch.define(:posts_comments) do |keys, context, plan_point|
-    #       Comment.where(post_id: keys).where(is_spam: false).group_by(&:post_id)
-    #     end
+    #   # Here we assume that CommentsCountBatchLoader and UserCompanyBatchLoader respond to #call
+    #   class UserSerializer < AppSerializer
+    #     attribute :id
+    #     attribute :comments_count, batch: { loader: CommentsCountBatchLoader, default: 0 }
+    #     attribute :company, serializer: CompanySerializer, batch: { loader: UserCompanyBatchLoader }
     #   end
     #
     module Batch

--- a/lib/serega/plugins/batch/lib/modules/attribute_normalizer.rb
+++ b/lib/serega/plugins/batch/lib/modules/attribute_normalizer.rb
@@ -64,7 +64,7 @@ class Serega
         end
 
         def prepare_batch_loader(loader)
-          return loader if loader.is_a?(Symbol)
+          loader = self.class.serializer_class.config.batch.loaders.fetch(loader) if loader.is_a?(Symbol)
 
           params_count = SeregaUtils::ParamsCount.call(loader, max_count: 3)
           case params_count

--- a/lib/serega/plugins/batch/lib/modules/plan_point.rb
+++ b/lib/serega/plugins/batch/lib/modules/plan_point.rb
@@ -13,25 +13,8 @@ class Serega
         # Returns attribute :batch option with prepared loader
         # @return [Hash] attribute :batch option
         #
-        attr_reader :batch
-
-        private
-
-        def set_normalized_vars
-          super
-          @batch = prepare_batch
-        end
-
-        def prepare_batch
-          batch = attribute.batch
-          if batch
-            loader = batch[:loader]
-            if loader.is_a?(Symbol)
-              batch_config = attribute.class.serializer_class.config.batch
-              batch[:loader] = batch_config.fetch_loader(loader)
-            end
-          end
-          batch
+        def batch
+          attribute.batch
         end
       end
     end

--- a/lib/serega/plugins/batch/lib/validations/check_batch_opt_loader.rb
+++ b/lib/serega/plugins/batch/lib/validations/check_batch_opt_loader.rb
@@ -17,17 +17,33 @@ class Serega
           #
           # @return [void]
           #
-          def call(loader)
-            return if loader.is_a?(Symbol)
+          def call(loader, serializer_class)
+            if loader.is_a?(Symbol)
+              check_symbol(loader, serializer_class)
+            else
+              check_callable(loader)
+            end
+          end
 
+          private
+
+          def check_symbol(loader_name, serializer_class)
+            defined_loaders = serializer_class.config.batch.loaders
+            return if defined_loaders[loader_name]
+
+            raise SeregaError, <<~ERR.strip
+              Please define loader before adding it to attribute.
+                Example: `config.batch.define(:#{loader_name}) { |ids| ... }`
+            ERR
+          end
+
+          def check_callable(loader)
             raise SeregaError, must_be_callable unless loader.respond_to?(:call)
 
             SeregaValidations::Utils::CheckExtraKeywordArg.call(loader, ":batch option :loader")
             params_count = SeregaUtils::ParamsCount.call(loader, max_count: 3)
             raise SeregaError, params_count_error if params_count > 3
           end
-
-          private
 
           def params_count_error
             "Invalid :batch option :loader. It can accept maximum 3 parameters (keys, context, plan)"

--- a/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
+++ b/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
@@ -26,8 +26,7 @@ class Serega
             SeregaValidations::Utils::CheckAllowedKeys.call(batch, %i[key loader default], :batch)
 
             check_batch_opt_key(batch, serializer_class)
-            check_batch_opt_loader(batch)
-
+            check_batch_opt_loader(batch, serializer_class)
             check_usage_with_other_params(opts, block)
           end
 
@@ -42,11 +41,11 @@ class Serega
             CheckBatchOptKey.call(key)
           end
 
-          def check_batch_opt_loader(batch)
+          def check_batch_opt_loader(batch, serializer_class)
             loader = batch[:loader]
             raise SeregaError, "Option :loader must present inside :batch option" unless loader
 
-            CheckBatchOptLoader.call(loader)
+            CheckBatchOptLoader.call(loader, serializer_class)
           end
 
           def check_usage_with_other_params(opts, block)

--- a/spec/serega/plugins/batch/lib/modules/attribute_spec.rb
+++ b/spec/serega/plugins/batch/lib/modules/attribute_spec.rb
@@ -5,7 +5,13 @@ require "support/activerecord"
 load_plugin_code :batch
 
 RSpec.describe Serega::SeregaPlugins::Batch do
-  let(:serializer) { Class.new(Serega) { plugin :batch } }
+  let(:serializer) do
+    Class.new(Serega) do
+      plugin :batch
+
+      config.batch.define(:loader, &proc {})
+    end
+  end
 
   describe "Attribute methods" do
     describe "#batch" do

--- a/spec/serega/plugins/batch/lib/modules/plan_point_spec.rb
+++ b/spec/serega/plugins/batch/lib/modules/plan_point_spec.rb
@@ -10,31 +10,12 @@ RSpec.describe Serega::SeregaPlugins::Batch do
   describe "PlanPoint methods" do
     describe "#batch" do
       it "returns provided attribute #batch option" do
-        loader = proc { |_keys| }
         attribute = serializer.attribute :foo,
-          batch: {loader: loader, key: :id}
+          batch: {loader: proc {}, key: :id}
 
         batch = serializer::SeregaPlanPoint.new("plan", attribute, []).batch
 
         expect(batch).to eq attribute.batch
-      end
-
-      it "uses loader from serializer config when Symbol provided" do
-        loader = proc { |_keys| }
-        serializer.config.batch.define(:loader_name, &loader)
-        attribute = serializer.attribute :foo,
-          batch: {loader: :loader_name, key: :id}
-
-        batch = serializer::SeregaPlanPoint.new("plan", attribute, []).batch
-        expect(batch[:loader]).to eq loader
-      end
-
-      it "raises error when loader not defined" do
-        attribute = serializer.attribute :foo,
-          batch: {loader: :loader_name, key: :id}
-
-        expect { serializer::SeregaPlanPoint.new("plan", attribute) }.to raise_error Serega::SeregaError,
-          start_with("Batch loader with name `:loader_name` was not defined")
       end
     end
   end

--- a/spec/serega/plugins/batch/lib/plugin_extensions/activerecord_preloads_spec.rb
+++ b/spec/serega/plugins/batch/lib/plugin_extensions/activerecord_preloads_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       p_serializer = post_serializer
       groups = method(:groups)
       Class.new(base_serializer) do
-        attribute :first_name
-        attribute :last_name
-        attribute :posts, serializer: p_serializer, batch: {key: :id, loader: :sorted_posts}
-
         config.batch.define(:sorted_posts) do |ids|
           groups.call(AR::Post.where(user_id: ids).order(:text), by: :user_id)
         end
+
+        attribute :first_name
+        attribute :last_name
+        attribute :posts, serializer: p_serializer, batch: {key: :id, loader: :sorted_posts}
       end
     end
 
@@ -84,11 +84,6 @@ RSpec.describe Serega::SeregaPlugins::Batch do
   context "with batch loaded static data" do
     let(:user_serializer) do
       Class.new(base_serializer) do
-        attribute :first_name
-        attribute :last_name
-        attribute :posts_count, batch: {key: :id, loader: :posts_count}
-        attribute :comments_count, batch: {key: :id, loader: :comments_count}
-
         config.batch.define(:posts_count) do |ids|
           AR::Post.where(user_id: ids).group(:user_id).count
         end
@@ -96,6 +91,11 @@ RSpec.describe Serega::SeregaPlugins::Batch do
         config.batch.define(:comments_count) do |ids|
           AR::Comment.joins(:post).where(posts: {user_id: ids}).group(:user_id).count
         end
+
+        attribute :first_name
+        attribute :last_name
+        attribute :posts_count, batch: {key: :id, loader: :posts_count}
+        attribute :comments_count, batch: {key: :id, loader: :comments_count}
       end
     end
 
@@ -115,13 +115,13 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       p_serializer = post_serializer
       groups = method(:groups)
       Class.new(base_serializer) do
-        attribute :first_name
-        attribute :last_name
-        attribute :posts, serializer: p_serializer, batch: {key: :id, loader: :sorted_posts}
-
         config.batch.define(:sorted_posts) do |ids|
           groups.call(AR::Post.where(user_id: ids).order(:text), by: :user_id)
         end
+
+        attribute :first_name
+        attribute :last_name
+        attribute :posts, serializer: p_serializer, batch: {key: :id, loader: :sorted_posts}
       end
     end
 
@@ -129,12 +129,12 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       c_serializer = comment_serializer
       groups = method(:groups)
       Class.new(base_serializer) do
-        attribute :text
-        attribute :comments, serializer: c_serializer, batch: {key: :id, loader: :sorted_comments}
-
         config.batch.define(:sorted_comments) do |ids|
           groups.call(AR::Comment.where(post_id: ids).order(:text), by: :post_id)
         end
+
+        attribute :text
+        attribute :comments, serializer: c_serializer, batch: {key: :id, loader: :sorted_comments}
       end
     end
 

--- a/spec/serega/plugins/batch/lib/plugin_extensions/formatters_spec.rb
+++ b/spec/serega/plugins/batch/lib/plugin_extensions/formatters_spec.rb
@@ -8,15 +8,14 @@ RSpec.describe Serega::SeregaPlugins::Batch do
       Class.new(Serega) do
         plugin :formatters
         plugin :batch
+        config.batch.define(:to_s) do |keys|
+          keys.zip(keys.map(&:to_s)).to_h
+        end
 
         attribute :first_name
 
         attribute :post, batch: {key: :post_id, loader: :to_s}
         attribute :post_reverse, batch: {key: :post_id, loader: :to_s}, format: proc { |value| value.reverse }
-
-        config.batch.define(:to_s) do |keys|
-          keys.zip(keys.map(&:to_s)).to_h
-        end
       end
     end
 

--- a/spec/serega/plugins/batch/lib/plugin_extensions/preloads_spec.rb
+++ b/spec/serega/plugins/batch/lib/plugin_extensions/preloads_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe Serega::SeregaPlugins::Batch do
   context "with preloads plugin" do
     let(:user_serializer) do
       post_ser = post_serializer
+
       Class.new(Serega) do
         plugin :preloads, auto_preload_attributes_with_serializer: true
         plugin :batch
 
-        attribute :one, batch: {key: :id, loader: :loader}, serializer: post_ser
+        attribute :one, batch: {key: :id, loader: proc {}}, serializer: post_ser
         attribute :two, serializer: post_ser
-        attribute :three, batch: {key: :id, loader: :loader}, serializer: post_ser, preload: :custom
+        attribute :three, batch: {key: :id, loader: proc {}}, serializer: post_ser, preload: :custom
       end
     end
 

--- a/spec/serega/plugins/batch/lib/validations/check_batch_opt_loader_spec.rb
+++ b/spec/serega/plugins/batch/lib/validations/check_batch_opt_loader_spec.rb
@@ -3,6 +3,8 @@
 load_plugin_code :batch
 
 RSpec.describe Serega::SeregaPlugins::Batch::CheckBatchOptLoader do
+  let(:serializer) { Class.new(Serega) { plugin :batch } }
+
   let(:params_count_error) do
     "Invalid :batch option :loader. It can accept maximum 3 parameters (keys, context, plan)"
   end
@@ -16,17 +18,17 @@ RSpec.describe Serega::SeregaPlugins::Batch::CheckBatchOptLoader do
   end
 
   it "prohibits non-proc, non-callable values" do
-    expect { described_class.call(nil) }.to raise_error Serega::SeregaError, must_be_callable
-    expect { described_class.call("String") }.to raise_error Serega::SeregaError, must_be_callable
-    expect { described_class.call([]) }.to raise_error Serega::SeregaError, must_be_callable
-    expect { described_class.call({}) }.to raise_error Serega::SeregaError, must_be_callable
-    expect { described_class.call(Object) }.to raise_error Serega::SeregaError, must_be_callable
-    expect { described_class.call(Object.new) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call(nil, serializer) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call("String", serializer) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call([], serializer) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call({}, serializer) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call(Object, serializer) }.to raise_error Serega::SeregaError, must_be_callable
+    expect { described_class.call(Object.new, serializer) }.to raise_error Serega::SeregaError, must_be_callable
   end
 
   it "prohibits to add loader with required keyword args" do
     value = proc { |a:| }
-    expect { described_class.call(value) }.to raise_error Serega::SeregaError, param_type_error
+    expect { described_class.call(value, serializer) }.to raise_error Serega::SeregaError, param_type_error
   end
 
   it "allows loaders with maximum 3 args" do
@@ -34,16 +36,25 @@ RSpec.describe Serega::SeregaPlugins::Batch::CheckBatchOptLoader do
     counter = Serega::SeregaUtils::ParamsCount
     allow(counter).to receive(:call).and_return(0, 1, 2, 3, 4)
 
-    expect { described_class.call(value) }.not_to raise_error
-    expect { described_class.call(value) }.not_to raise_error
-    expect { described_class.call(value) }.not_to raise_error
-    expect { described_class.call(value) }.not_to raise_error
-    expect { described_class.call(value) }.to raise_error Serega::SeregaError, params_count_error
+    expect { described_class.call(value, serializer) }.not_to raise_error
+    expect { described_class.call(value, serializer) }.not_to raise_error
+    expect { described_class.call(value, serializer) }.not_to raise_error
+    expect { described_class.call(value, serializer) }.not_to raise_error
+    expect { described_class.call(value, serializer) }.to raise_error Serega::SeregaError, params_count_error
 
     expect(counter).to have_received(:call).with(value, max_count: 3).exactly(5).times
   end
 
-  it "allows symbols" do
-    expect { described_class.call(:foo) }.not_to raise_error
+  context "when Symbol provided as loader_name" do
+    it "raises error if loader was not defined" do
+      expect { described_class.call(:foo, serializer) }
+        .to raise_error Serega::SeregaError,
+          "Please define loader before adding it to attribute.\n  Example: `config.batch.define(:foo) { |ids| ... }`"
+    end
+
+    it "does not raise error when loader was not defined earlier" do
+      serializer.config.batch.define(:foo, proc {})
+      expect { described_class.call(:foo, serializer) }.not_to raise_error
+    end
   end
 end

--- a/spec/serega/plugins/batch/lib/validations/check_opt_batch_spec.rb
+++ b/spec/serega/plugins/batch/lib/validations/check_opt_batch_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe Serega::SeregaPlugins::Batch::CheckOptBatch do
   end
 
   it "checks sub option :key is present" do
-    opts[:batch] = {loader: :abc}
+    opts[:batch] = {loader: proc {}}
     expect { check }.to raise_error Serega::SeregaError, "Option :key must present inside :batch option"
   end
 
   it "allows to skip sub option :key if default key specified" do
     serializer.config.batch.default_key = :id
-    opts[:batch] = {loader: :abc}
+    opts[:batch] = {loader: proc {}}
     expect { check }.not_to raise_error
   end
 
@@ -42,41 +42,41 @@ RSpec.describe Serega::SeregaPlugins::Batch::CheckOptBatch do
 
   it "checks sub options :key and :loader" do
     opts[:batch] = {key: :key_name, loader: :loader_name}
-    allow(Serega::SeregaPlugins::Batch::CheckBatchOptLoader).to receive(:call).with(:loader_name)
-    allow(Serega::SeregaPlugins::Batch::CheckBatchOptKey).to receive(:call).with(:key_name)
+    allow(Serega::SeregaPlugins::Batch::CheckBatchOptLoader).to receive(:call)
+    allow(Serega::SeregaPlugins::Batch::CheckBatchOptKey).to receive(:call)
 
     check
 
-    expect(Serega::SeregaPlugins::Batch::CheckBatchOptLoader).to have_received(:call).with(:loader_name)
+    expect(Serega::SeregaPlugins::Batch::CheckBatchOptLoader).to have_received(:call).with(:loader_name, serializer)
     expect(Serega::SeregaPlugins::Batch::CheckBatchOptKey).to have_received(:call).with(:key_name)
   end
 
   it "prohibits to use with :method opt" do
-    opts.merge!(batch: {key: :key, loader: :loader}, method: :method)
+    opts.merge!(batch: {key: :key, loader: proc {}}, method: :method)
     expect { check }
       .to raise_error Serega::SeregaError, "Option :batch can not be used together with option :method"
   end
 
   it "prohibits to use with :value opt" do
-    opts.merge!(batch: {key: :key, loader: :loader}, value: -> {})
+    opts.merge!(batch: {key: :key, loader: proc {}}, value: -> {})
     expect { check }
       .to raise_error Serega::SeregaError, "Option :batch can not be used together with option :value"
   end
 
   it "prohibits to use with :const opt" do
-    opts.merge!(batch: {key: :key, loader: :loader}, const: 1)
+    opts.merge!(batch: {key: :key, loader: proc {}}, const: 1)
     expect { check }
       .to raise_error Serega::SeregaError, "Option :batch can not be used together with option :const"
   end
 
   it "prohibits to use with :delegate opt" do
-    opts.merge!(batch: {key: :key, loader: :loader}, delegate: {to: :foo})
+    opts.merge!(batch: {key: :key, loader: proc {}}, delegate: {to: :foo})
     expect { check }
       .to raise_error Serega::SeregaError, "Option :batch can not be used together with option :delegate"
   end
 
   it "prohibits to use with block" do
-    opts[:batch] = {key: :key, loader: :loader}
+    opts[:batch] = {key: :key, loader: proc {}}
     expect { described_class.call(opts, proc {}, serializer) }
       .to raise_error Serega::SeregaError, "Option :batch can not be used together with block"
   end


### PR DESCRIPTION
https://github.com/aglushkov/serega/issues/136

This way we can find error about not existing batch loader earlier.

Most of the time user will not reuse loaders, as they are quite unique by nature. But if they want to reuse it, they will probably define it in parent serializer, so it should not be a problem

Also prefferable way to use batch loaders is to provide callable object directly.