### PR TITLE
Add :default attribute option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- Added :default option for attributes. If :default is specified than found
+  nils will be replaced with this value. Also when :default option is not
+  specified we us empty array as a default if `many: true` option is specified
+- Remove :batch plugin :default option. It can be replaced with the new global
+  :default option.
+
 ## [0.18.0] - 2023-11-11
 
 - Rename batch plugin option `key` to `id_method`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     allocation_stats (0.1.5)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.5)
     chef-utils (18.3.0)
       concurrent-ruby
     concurrent-ruby (1.2.2)
@@ -129,7 +129,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (1.6.8-x86_64-linux)
+    sqlite3 (1.6.9-x86_64-linux)
     standard (1.32.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ class UserSerializer < AppSerializer
 end
 ```
 
-#### Option :default
+#### Default value
 
 The default value for attributes without found value can be specified via
 `:default` option. By default, attributes without found value will be
@@ -675,8 +675,7 @@ class UserSerializer < AppSerializer
     many: true
 
   # Missing values become `0` as specified directly
-  attribute :points_amount,
-    batch: { loader: proc {}, default: 0 }
+  attribute :points_amount, batch: { loader: proc {} }, default: 0
 end
 ```
 

--- a/examples/batch_loader.rb
+++ b/examples/batch_loader.rb
@@ -87,22 +87,6 @@ View.create!(comment: comment2, count: 2)
 View.create!(comment: comment3, count: 3)
 View.create!(comment: comment4, count: 4)
 
-def groups(keys, values, by:, default: nil)
-  data =
-    values.each_with_object({}) do |element, groups|
-      key = element.public_send(by)
-
-      if groups.has_key?(key)
-        groups[key] << element
-      else
-        groups[key] = [element]
-      end
-    end
-
-  keys.each { |key| data[key] ||= default }
-  data
-end
-
 class UsersPostsLoader
   def self.call(user_ids)
     Post

--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -21,6 +21,10 @@ class Serega
       # @return [Boolean, nil] Attribute :many option
       attr_reader :many
 
+      # Attribute :default option
+      # @return [Object, nil] Attribute :default option
+      attr_reader :default
+
       # Attribute :hide option
       # @return [Boolean, nil] Attribute :hide option
       attr_reader :hide
@@ -108,9 +112,10 @@ class Serega
 
       def set_normalized_vars(normalizer)
         @name = normalizer.name
+        @many = normalizer.many
+        @default = normalizer.default
         @value_block = normalizer.value_block
         @hide = normalizer.hide
-        @many = normalizer.many
         @serializer = normalizer.serializer
       end
     end

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -15,7 +15,7 @@ class Serega
     DEFAULTS = {
       plugins: [],
       initiate_keys: %i[only with except check_initiate_params].freeze,
-      attribute_keys: %i[method value serializer many hide const delegate].freeze,
+      attribute_keys: %i[method value serializer many hide const delegate default].freeze,
       serialize_keys: %i[context many].freeze,
       check_attribute_name: true,
       check_initiate_params: true,

--- a/lib/serega/plugins/batch/batch.rb
+++ b/lib/serega/plugins/batch/batch.rb
@@ -14,7 +14,7 @@ class Serega
     #   end
     #
     #   class UserSerializer < AppSerializer
-    #     attribute :comments_count, batch: { loader: CommentsCountBatchLoader, default: 0 }
+    #     attribute :comments_count, batch: { loader: CommentsCountBatchLoader }, default: 0
     #     attribute :company, serializer: CompanySerializer, batch: { loader: UserCompanyBatchLoader }
     #   end
     #

--- a/lib/serega/plugins/batch/lib/modules/attribute_normalizer.rb
+++ b/lib/serega/plugins/batch/lib/modules/attribute_normalizer.rb
@@ -47,8 +47,6 @@ class Serega
           id_method = batch[:id_method] || self.class.serializer_class.config.batch.id_method
           id_method = prepare_batch_id_method(id_method)
 
-          default = batch.fetch(:default) { many ? FROZEN_EMPTY_ARRAY : nil }
-
           {loader: loader, id_method: id_method, default: default}
         end
 

--- a/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
+++ b/lib/serega/plugins/batch/lib/validations/check_opt_batch.rb
@@ -23,7 +23,7 @@ class Serega
             SeregaValidations::Utils::CheckOptIsHash.call(opts, :batch)
 
             batch = opts[:batch]
-            SeregaValidations::Utils::CheckAllowedKeys.call(batch, %i[id_method loader default], :batch)
+            SeregaValidations::Utils::CheckAllowedKeys.call(batch, %i[id_method loader], :batch)
 
             check_batch_opt_id_method(batch, serializer_class)
             check_batch_opt_loader(batch, serializer_class)

--- a/spec/serega/attribute_normalizer_spec.rb
+++ b/spec/serega/attribute_normalizer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
   describe "#prepare_value_block" do
     it "returns normalized block when it accepts 0 arguments" do
       block = lambda { 123 }
-      attribute = normalizer.new(block: block)
+      attribute = normalizer.new(block: block, opts: {})
       value_block = attribute.send(:prepare_value_block)
       expect(value_block).not_to eq block
       expect(value_block.call(1, 2)).to eq 123
@@ -86,7 +86,7 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
 
     it "returns normalized block if it accepts only 1 argument" do
       block = lambda { |a| a }
-      attribute = normalizer.new(block: block)
+      attribute = normalizer.new(block: block, opts: {})
       value_block = attribute.send(:prepare_value_block)
       expect(value_block).not_to eq block
       expect(value_block.call(1, 2)).to eq 1
@@ -160,6 +160,20 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
       expect(block).to be_a Proc
       expect(block.call(object1)).to be_nil
       expect(block.call(object2)).to eq "NAME"
+    end
+
+    it "returns default value when initial block returns nil" do
+      value = lambda {}
+      attribute = normalizer.new(opts: {value: value, default: 123})
+      value_block = attribute.send(:prepare_value_block)
+      expect(value_block.call(1, 2)).to eq 123
+    end
+
+    it "does not return default value when initial block does not return nil" do
+      value = lambda { 987 }
+      attribute = normalizer.new(opts: {value: value, default: 123})
+      value_block = attribute.send(:prepare_value_block)
+      expect(value_block.call(1, 2)).to eq 987
     end
   end
 end

--- a/spec/serega/attribute_spec.rb
+++ b/spec/serega/attribute_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Serega::SeregaAttribute do
         serializer_class::SeregaAttributeNormalizer,
         name: nil,
         many: nil,
+        default: nil,
         hide: nil,
         serializer: nil,
         method: nil,
@@ -45,7 +46,7 @@ RSpec.describe Serega::SeregaAttribute do
       allow(serializer_class::SeregaAttributeNormalizer).to receive(:new).with(initials).and_return(normalizer)
       attribute = attribute_class.new(**initials)
 
-      expect(attribute.instance_variables).to include(:@name, :@value_block, :@many, :@hide, :@serializer)
+      expect(attribute.instance_variables).to include(:@name, :@default, :@value_block, :@many, :@hide, :@serializer)
     end
   end
 

--- a/spec/serega/plugins/batch/lib/modules/attribute_spec.rb
+++ b/spec/serega/plugins/batch/lib/modules/attribute_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe Serega::SeregaPlugins::Batch do
     describe "#batch" do
       it "returns provided options with transformed Symbol id_method to Proc" do
         batch_loader = proc { |*args| }
-        at = serializer.attribute :at1, batch: {id_method: :id, loader: batch_loader, default: :default}
+        at = serializer.attribute :at1, batch: {id_method: :id, loader: batch_loader}
         expect(at.batch).to include(loader: batch_loader)
-        expect(at.batch).to include(default: :default)
         expect(at.batch).to include(id_method: be_a(Proc))
 
         object = double(id: "ID")
@@ -48,14 +47,19 @@ RSpec.describe Serega::SeregaPlugins::Batch do
         expect(at.batch[:id_method].call(1)).to eq :foo
       end
 
-      it "adds `default: nil` if attribute :many option not specified" do
-        at = serializer.attribute :at, batch: {id_method: :id, loader: :loader}
-        expect(at.batch).to include({default: nil})
+      it "adds `default` options if attribute `default` option specified" do
+        at = serializer.attribute :at1, batch: {id_method: :id, loader: :loader}, default: :foo
+        expect(at.batch).to include(default: :foo)
       end
 
       it "adds `default: []` if attribute :many option is set" do
         at = serializer.attribute :at, batch: {id_method: :id, loader: :loader}, many: true
         expect(at.batch).to include({default: []})
+      end
+
+      it "adds `default: nil` if attribute :default and :many options are not specified" do
+        at = serializer.attribute :at, batch: {id_method: :id, loader: :loader}
+        expect(at.batch).to include({default: nil})
       end
     end
 

--- a/spec/serega/plugins/batch/lib/validations/check_opt_batch_spec.rb
+++ b/spec/serega/plugins/batch/lib/validations/check_opt_batch_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Serega::SeregaPlugins::Batch::CheckOptBatch do
   end
 
   it "checks allowed keys" do
-    opts[:batch] = {id_method: nil, loader: nil, default: nil, foo: nil}
+    opts[:batch] = {id_method: nil, loader: nil, foo: nil}
     expect { check }.to raise_error Serega::SeregaError, /foo/
   end
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Serega do
       expect(config.plugins).to eq []
       expect(config.serialize_keys).to match_array(%i[context many])
       expect(config.initiate_keys).to match_array(%i[only except with check_initiate_params])
-      expect(config.attribute_keys).to match_array(%i[method value serializer many hide const delegate])
+      expect(config.attribute_keys).to match_array(%i[method value serializer many hide const delegate default])
       expect(config.check_attribute_name).to be true
       expect(config.check_initiate_params).to be true
       expect(config.delegate_default_allow_nil).to be false


### PR DESCRIPTION
1. The :default option can be specified to replace attribute nil values.

```ruby
attribute: :some_count, default: 0
```

2. Also removed :batch plugin `:default` option, as new option replaces it

```ruby
attribute: :some_count, batch: { loader: SomeCountLoader, default: 0 }

attribute: :some_count, batch: { loader: SomeCountLoader }, default: 0
```