### PR TITLE
Remove extra allocations

### DIFF
--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "forwardable"
-
 class Serega
   #
   # Stores serialization config

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -38,8 +38,8 @@ class Serega
 
       private
 
-      def serialize_array(object)
-        object.map { |obj| serialize_object(obj) }
+      def serialize_array(objects)
+        objects.map { |object| serialize_object(object) }
       end
 
       # Patched in:
@@ -79,11 +79,16 @@ class Serega
       end
 
       def relation_value(value, point)
-        child_plan = point.child_plan
-        child_serializer = point.child_object_serializer
-        child_many = point.many
-        serializer = child_serializer.new(context: context, plan: child_plan, many: child_many, **opts)
-        serializer.serialize(value)
+        child_serializer(point).serialize(value)
+      end
+
+      def child_serializer(point)
+        point.child_object_serializer.new(
+          context: context,
+          plan: point.child_plan,
+          many: point.many,
+          **opts
+        )
       end
 
       def array?(object, many)

--- a/lib/serega/plan_point.rb
+++ b/lib/serega/plan_point.rb
@@ -9,8 +9,6 @@ class Serega
     # SeregaPlanPoint instance methods
     #
     module InstanceMethods
-      extend Forwardable
-
       # Link to current plan this point belongs to
       # @return [SeregaAttribute] Current plan
       attr_reader :plan
@@ -26,20 +24,6 @@ class Serega
       # Child fields to serialize
       # @return [Hash] Attributes to serialize
       attr_reader :modifiers
-
-      # @!method name
-      #   Attribute `name`
-      #   @see SeregaAttribute::AttributeInstanceMethods#name
-      # @!method value
-      #   Attribute `value` block
-      #   @see SeregaAttribute::AttributeInstanceMethods#value
-      # @!method many
-      #   Attribute `many` option
-      #   @see SeregaAttribute::AttributeInstanceMethods#many
-      # @!method serializer
-      #   Attribute `serializer` option
-      #   @see SeregaAttribute::AttributeInstanceMethods#serializer
-      def_delegators :@attribute, :name, :value, :many, :serializer
 
       #
       # Initializes plan point
@@ -58,6 +42,30 @@ class Serega
         @attribute = attribute
         @modifiers = modifiers
         set_normalized_vars
+      end
+
+      # Attribute `value`
+      # @see SeregaAttribute::AttributeInstanceMethods#value
+      def value(obj, ctx)
+        attribute.value(obj, ctx)
+      end
+
+      # Attribute `name`
+      # @see SeregaAttribute::AttributeInstanceMethods#value
+      def name
+        attribute.name
+      end
+
+      # Attribute `many` option
+      # @see SeregaAttribute::AttributeInstanceMethods#many
+      def many
+        attribute.many
+      end
+
+      # Attribute `serializer` option
+      # @see SeregaAttribute::AttributeInstanceMethods#serializer
+      def serializer
+        attribute.serializer
       end
 
       #


### PR DESCRIPTION
Ruby allocates extra array when forwading methods (probably to forward arguments) As we know methods arity, we can improve this behaviour.