### PR TITLE
Add extra metadata methods to Serega::AttributeNotExist error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+- Add additional methods to Serega::AttributeNotExist:
+
+   - `Serega::AttributeNotExist#serializer` Shows current serializer.
+     Can help when you use multiple serializers and want to find which one is
+     responsible for the error;
+   - `Serega::AttributeNotExist#attributes` Lists not existing attributes.
+
+- Fix extra allocations by replacing forwardable methods with plain ruby methods
+
 ## [0.19.0] - 2023-12-17
 
 - Added :default option for attributes. The `default` option value will replace

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ fields_as_string = 'first_name,enemy'
 UserSerializer.new(only: fields).to_h(bruce)
 UserSerializer.to_h(bruce, only: fields)
 UserSerializer.to_h(bruce, only: fields_as_string)
-# => raises Serega::AttributeNotExist, "Attribute 'enemy' not exists"
+# => raises Serega::AttributeNotExist
 
 # With no existing attribute and disabled validation
 fields = %i[first_name enemy]
@@ -1074,7 +1074,10 @@ a single object.
 
 - The `Serega::SeregaError` is a base error raised by this gem.
 - The `Serega::AttributeNotExist` error is raised when validating attributes in
-  `:only, :except, :with` modifiers
+  `:only, :except, :with` modifiers. This error contains additional metadata:
+
+   - error.serializer - shows current serializer
+   - error.attributes - lists not existing attributes
 
 ## Release
 

--- a/lib/serega/errors.rb
+++ b/lib/serega/errors.rb
@@ -11,5 +11,13 @@ class Serega
   # @example
   #   Serega.new(only: 'FOO')
   #   # => Attribute 'FOO' not exists (Serega::AttributeNotExist)
-  class AttributeNotExist < SeregaError; end
+  class AttributeNotExist < SeregaError
+    attr_reader :serializer, :attributes
+
+    def initialize(message = nil, serializer = nil, attributes = nil)
+      super(message)
+      @serializer = serializer
+      @attributes = attributes
+    end
+  end
 end

--- a/spec/serega/validations/initiate/check_modifiers_spec.rb
+++ b/spec/serega/validations/initiate/check_modifiers_spec.rb
@@ -42,16 +42,30 @@ RSpec.describe Serega::SeregaValidations::Initiate::CheckModifiers do
 
   it "raises when provided not existing attribute in nested serializer" do
     attrs = "foo_bazz(extra)"
-    message = "Not existing attributes: foo_bazz.extra"
-    expect { serializer.new(only: attrs) }.to raise_error Serega::AttributeNotExist, message
+    message = "Not existing attributes: foo_bazz(extra)"
+
+    expect { serializer.new(only: attrs) }.to raise_error do |error|
+      expect(error).to be_a Serega::AttributeNotExist
+      expect(error.message).to eq message
+      expect(error.serializer).to eq serializer
+      expect(error.attributes).to eq ["foo_bazz(extra)"]
+    end
+
     expect { serializer.new(with: attrs) }.to raise_error Serega::AttributeNotExist, message
     expect { serializer.new(except: attrs) }.to raise_error Serega::AttributeNotExist, message
   end
 
   it "raises when provided nested attribute for not nested parent attribute" do
     attrs = "foo_bar(extra)"
-    message = "Not existing attributes: foo_bar.extra"
-    expect { serializer.new(only: attrs) }.to raise_error Serega::AttributeNotExist, message
+    message = "Not existing attributes: foo_bar(extra)"
+
+    expect { serializer.new(only: attrs) }.to raise_error do |error|
+      expect(error).to be_a Serega::AttributeNotExist
+      expect(error.message).to eq message
+      expect(error.serializer).to eq serializer
+      expect(error.attributes).to eq ["foo_bar(extra)"]
+    end
+
     expect { serializer.new(with: attrs) }.to raise_error Serega::AttributeNotExist, message
     expect { serializer.new(except: attrs) }.to raise_error Serega::AttributeNotExist, message
   end


### PR DESCRIPTION
https://github.com/aglushkov/serega/issues/144

- `Serega::AttributeNotExist#serializer` Shows current serializer. Can help when you use multiple serializers and want to find which one is responsible for the error;
- `Serega::AttributeNotExist#attributes` Lists not existing attributes.