### PR TITLE
Allow to return hash with stringified keys

### DIFF
--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -14,8 +14,12 @@ class Serega
       attr_reader :initials
 
       # Attribute name
-      # @return [Symbol] Attribute name
+      # @return [String] Attribute name as String
       attr_reader :name
+
+      # Attribute symbol name
+      # @return [Symbol] Attribute name as Symbol
+      attr_reader :symbol_name
 
       # Attribute :many option
       # @return [Boolean, nil] Attribute :many option
@@ -112,6 +116,7 @@ class Serega
 
       def set_normalized_vars(normalizer)
         @name = normalizer.name
+        @symbol_name = normalizer.symbol_name
         @many = normalizer.many
         @default = normalizer.default
         @value_block = normalizer.value_block

--- a/lib/serega/attribute_normalizer.rb
+++ b/lib/serega/attribute_normalizer.rb
@@ -27,12 +27,21 @@ class Serega
       end
 
       #
+      # Stringified initial attribute name
+      #
+      # @return [String] Attribute normalized name
+      #
+      def name
+        @name ||= prepare_name
+      end
+
+      #
       # Symbolized initial attribute name
       #
       # @return [Symbol] Attribute normalized name
       #
-      def name
-        @name ||= prepare_name
+      def symbol_name
+        @symbol_name ||= name.to_sym
       end
 
       #
@@ -102,7 +111,7 @@ class Serega
       private
 
       def prepare_name
-        init_name.to_sym
+        SeregaUtils::SymbolName.call(init_name)
       end
 
       #

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -14,7 +14,7 @@ class Serega
       plugins: [],
       initiate_keys: %i[only with except check_initiate_params].freeze,
       attribute_keys: %i[method value serializer many hide const delegate default].freeze,
-      serialize_keys: %i[context many].freeze,
+      serialize_keys: %i[context many symbol_keys].freeze,
       check_attribute_name: true,
       check_initiate_params: true,
       delegate_default_allow_nil: false,

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -10,7 +10,7 @@ class Serega
     # SeregaObjectSerializer instance methods
     #
     module InstanceMethods
-      attr_reader :context, :plan, :many, :opts
+      attr_reader :context, :plan, :many, :symbol_keys, :opts
 
       # @param plan [SeregaPlan] Serialization plan
       # @param context [Hash] Serialization context
@@ -18,10 +18,11 @@ class Serega
       # @param opts [Hash] Any custom options
       #
       # @return [SeregaObjectSerializer] New SeregaObjectSerializer
-      def initialize(context:, plan:, many: nil, **opts)
+      def initialize(context:, plan:, many: nil, symbol_keys: false, **opts)
         @context = context
         @plan = plan
         @many = many
+        @symbol_keys = symbol_keys
         @opts = opts
       end
 
@@ -72,7 +73,11 @@ class Serega
       # - plugin :if (conditionally skips attaching)
       # - plugin :batch :if extension (removes prepared key)
       def attach_final_value(final_value, point, container)
-        container[point.name] = final_value
+        container[key(point)] = final_value
+      end
+
+      def key(point)
+        symbol_keys ? point.symbol_name : point.name
       end
 
       def final_value(value, point)
@@ -86,6 +91,7 @@ class Serega
       def child_serializer(point)
         point.child_object_serializer.new(
           context: context,
+          symbol_keys: symbol_keys,
           plan: point.child_plan,
           many: point.many,
           **opts

--- a/lib/serega/plan_point.rb
+++ b/lib/serega/plan_point.rb
@@ -51,9 +51,15 @@ class Serega
       end
 
       # Attribute `name`
-      # @see SeregaAttribute::AttributeInstanceMethods#value
+      # @see SeregaAttribute::AttributeInstanceMethods#name
       def name
         attribute.name
+      end
+
+      # Attribute `symbol_name`
+      # @see SeregaAttribute::AttributeInstanceMethods#symbol_name
+      def symbol_name
+        attribute.symbol_name
       end
 
       # Attribute `many` option

--- a/lib/serega/plugins/batch/batch.rb
+++ b/lib/serega/plugins/batch/batch.rb
@@ -107,7 +107,7 @@ class Serega
 
         if serializer_class.plugin_used?(:if)
           require_relative "lib/plugins_extensions/if"
-          serializer_class::SeregaObjectSerializer.include(PluginsExtensions::If::ObjectSerializerInstanceMethods123)
+          serializer_class::SeregaObjectSerializer.include(PluginsExtensions::If::ObjectSerializerInstanceMethods)
         end
 
         if serializer_class.plugin_used?(:preloads)

--- a/lib/serega/plugins/batch/lib/modules/object_serializer.rb
+++ b/lib/serega/plugins/batch/lib/modules/object_serializer.rb
@@ -21,7 +21,7 @@ class Serega
         def remember_key_for_batch_loading(batch, object, point, container)
           id = batch[:id_method].call(object, context)
           batch_loader(point).remember(id, container)
-          container[point.name] = nil # Reserve attribute place in resulted hash. We will set correct value later
+          container[key(point)] = nil # Reserve attribute place in resulted hash. We will set correct value later
         end
 
         def batch_loader(point)

--- a/lib/serega/plugins/batch/lib/plugins_extensions/if.rb
+++ b/lib/serega/plugins/batch/lib/plugins_extensions/if.rb
@@ -16,12 +16,14 @@ class Serega
           #
           # @see Serega::SeregaObjectSerializer
           #
-          module ObjectSerializerInstanceMethods123
+          module ObjectSerializerInstanceMethods
             private
 
             # Removes key added by `batch` plugin at the start of serialization to preserve attributes ordering
             def attach_final_value(value, point, container)
-              container.delete(point.name) if super == SeregaPlugins::If::KEY_SKIPPED
+              if super == SeregaPlugins::If::KEY_SKIPPED
+                container.delete(key(point))
+              end
             end
           end
         end

--- a/lib/serega/plugins/camel_case/camel_case.rb
+++ b/lib/serega/plugins/camel_case/camel_case.rb
@@ -39,8 +39,8 @@ class Serega
     module CamelCase
       # Default camel-case transformation
       TRANSFORM_DEFAULT = proc { |attribute_name|
-        attribute_name.gsub!(/_[a-z]/) { |m| m[-1].upcase! }
-        attribute_name
+        camel_cased_name = attribute_name.to_s.gsub(/_[a-z]/) { |m| m[-1].upcase! }
+        camel_cased_name.freeze
       }
 
       # @return [Symbol] Plugin name
@@ -203,7 +203,7 @@ class Serega
           res = super
           return res if init_opts[:camel_case] == false
 
-          self.class.serializer_class.config.camel_case.transform.call(res.to_s).to_sym
+          self.class.serializer_class.config.camel_case.transform.call(res)
         end
       end
     end

--- a/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
+++ b/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
@@ -87,7 +87,7 @@ class Serega
           def extract_attribute(fields, start_index, end_index)
             attribute = fields[start_index, end_index - start_index]
             attribute.strip!
-            attribute.empty? ? nil : attribute.to_sym
+            attribute.empty? ? nil : attribute.freeze
           end
 
           def add_attribute(storage, attribute, nested_attributes = FROZEN_EMPTY_HASH)

--- a/lib/serega/utils/symbol_name.rb
+++ b/lib/serega/utils/symbol_name.rb
@@ -15,7 +15,11 @@ class Serega
         # @return [String] frozen string corresponding to provided symbol
         #
         def call(key)
-          key.is_a?(String) ? key : to_frozen_string(key)
+          if key.is_a?(Symbol)
+            to_frozen_string(key)
+          else
+            key.frozen? ? key : key.dup.freeze
+          end
         end
 
         private

--- a/lib/serega/utils/to_stringified_hash.rb
+++ b/lib/serega/utils/to_stringified_hash.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaUtils
+    #
+    # Utility to transform almost anything to Hash with strigified frozen keys
+    #
+    class ToStringifiedHash
+      class << self
+        #
+        # Constructs deep hashes from provided data
+        #
+        # @param value [Array, Hash, String, Symbol, NilClass, FalseClass] Value to transform
+        #
+        # @example
+        #   Serega::SeregaUtils::ToHash.(nil) # => {}
+        #   Serega::SeregaUtils::ToHash.(false) # => {}
+        #   Serega::SeregaUtils::ToHash.(:foo) # => {:foo=>{}}
+        #   Serega::SeregaUtils::ToHash.("foo") # => {:foo=>{}}
+        #   Serega::SeregaUtils::ToHash.(%w[foo bar]) # => {:foo=>{}, :bar=>{}}
+        #   Serega::SeregaUtils::ToHash.({ foo: nil, bar: false }) # => {:foo=>{}, :bar=>{}}
+        #   Serega::SeregaUtils::ToHash.({ foo: :bar }) # => {:foo=>{:bar=>{}}}
+        #   Serega::SeregaUtils::ToHash.({ foo: [:bar] }) # => {:foo=>{:bar=>{}}}
+        #
+        # @return [Hash] Transformed data
+        #
+        def call(value)
+          case value
+          when Array then array_to_hash(value)
+          when Hash then hash_to_hash(value)
+          when NilClass, FalseClass then nil_to_hash(value)
+          when String, Symbol then string_to_hash(value)
+          else raise SeregaError, "Can't convert #{value.class} class object to hash"
+          end
+        end
+
+        private
+
+        def array_to_hash(values)
+          return FROZEN_EMPTY_HASH if values.empty?
+
+          res = {}
+          values.each do |value|
+            case value
+            when String, Symbol
+              key = to_key(value)
+              res[key] = FROZEN_EMPTY_HASH
+            else
+              res.merge!(call(value))
+            end
+          end
+          res
+        end
+
+        def hash_to_hash(values)
+          return FROZEN_EMPTY_HASH if values.empty?
+
+          res = {}
+          values.each do |key, value|
+            key = to_key(key)
+            value = call(value)
+            res[key] = value
+          end
+          res
+        end
+
+        def nil_to_hash(_value)
+          FROZEN_EMPTY_HASH
+        end
+
+        def string_to_hash(value)
+          key = to_key(value)
+          {key => FROZEN_EMPTY_HASH}
+        end
+
+        def to_key(value)
+          SymbolName.call(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/serega/validations/check_serialize_params.rb
+++ b/lib/serega/validations/check_serialize_params.rb
@@ -37,6 +37,7 @@ class Serega
 
           Utils::CheckOptIsHash.call(opts, :context)
           Utils::CheckOptIsBool.call(opts, :many)
+          Utils::CheckOptIsBool.call(opts, :symbol_keys)
         end
 
         def serializer_class

--- a/lib/serega/validations/initiate/check_modifiers.rb
+++ b/lib/serega/validations/initiate/check_modifiers.rb
@@ -71,14 +71,15 @@ class Serega
 
         def build_full_attribute_name(*names)
           head, *nested = *names
-          result = head.to_s # names are symbols, we need not frozen string
-          nested.each { |nested_name| result << "(" << nested_name.to_s }
+          result = head.dup # names are strings, we need not frozen one to start with
+          nested.each { |nested_name| result << "(" << nested_name }
           nested.each { result << ")" }
           result
         end
 
         def raise_errors(serializer_class)
-          raise Serega::AttributeNotExist.new("Not existing attributes: #{error_attributes.join(", ")}", serializer_class, error_attributes)
+          attrs = error_attributes.join(", ")
+          raise Serega::AttributeNotExist.new("Not existing attributes: #{attrs}", serializer_class, error_attributes)
         end
 
         def any_error?

--- a/spec/serega/attribute_normalizer_spec.rb
+++ b/spec/serega/attribute_normalizer_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
   let(:normalizer) { serializer_class::SeregaAttributeNormalizer }
 
   describe "#name" do
-    it "symbolizes name" do
-      attribute = normalizer.new(name: "current_name")
-      expect(attribute.name).to eq :current_name
+    it "returns frozen string" do
+      attribute = normalizer.new(name: :current_name)
+      expect(attribute.name).to eq "current_name"
+      expect(attribute.name).to be_frozen
     end
   end
 

--- a/spec/serega/attribute_spec.rb
+++ b/spec/serega/attribute_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Serega::SeregaAttribute do
       normalizer = instance_double(
         serializer_class::SeregaAttributeNormalizer,
         name: nil,
+        symbol_name: nil,
         many: nil,
         default: nil,
         hide: nil,
@@ -46,7 +47,8 @@ RSpec.describe Serega::SeregaAttribute do
       allow(serializer_class::SeregaAttributeNormalizer).to receive(:new).with(initials).and_return(normalizer)
       attribute = attribute_class.new(**initials)
 
-      expect(attribute.instance_variables).to include(:@name, :@default, :@value_block, :@many, :@hide, :@serializer)
+      expect(attribute.instance_variables)
+        .to include(:@name, :@symbol_name, :@default, :@value_block, :@many, :@hide, :@serializer)
     end
   end
 
@@ -108,15 +110,15 @@ RSpec.describe Serega::SeregaAttribute do
     end
 
     def except(key)
-      {except: {key => {}}, only: {}, with: {}}
+      {except: {key.to_s => {}}, only: {}, with: {}}
     end
 
     def only(key)
-      {except: {}, only: {key => {}}, with: {}}
+      {except: {}, only: {key.to_s => {}}, with: {}}
     end
 
     def with(key)
-      {except: {}, only: {}, with: {key => {}}}
+      {except: {}, only: {}, with: {key.to_s => {}}}
     end
 
     it "returns by default true when attribute is not hidden" do
@@ -145,7 +147,7 @@ RSpec.describe Serega::SeregaAttribute do
 
     it "skips :except parameter if it has nested keys" do
       args = except(:name)
-      args[:except][:name] = {foo: {}}
+      args[:except]["name"] = {"foo" => {}}
 
       expect(attribute_class.new(name: :name).visible?(**args)).to be true
     end

--- a/spec/serega/plan_spec.rb
+++ b/spec/serega/plan_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Serega::SeregaPlan do
       expect(result.points.count).to eq names.count
 
       names.each do |key, child_keys|
-        point = result.points.find { |point| point.name == key }
+        point = result.points.find { |point| point.name.to_s == key.to_s }
         expect(point).not_to be_nil
         expect(point.child_plan).to satisfy_attribute_names(child_keys) if child_keys
       end
@@ -66,7 +66,7 @@ RSpec.describe Serega::SeregaPlan do
     end
 
     it "returns only attributes from :only option" do
-      result = plan(only: {a2: {}, d: {d1: {}}}, except: {}, with: {})
+      result = plan(only: {"a2" => {}, "d" => {"d1" => {}}}, except: {}, with: {})
 
       expect(result).to satisfy_attribute_names(
         a2: nil,
@@ -75,7 +75,7 @@ RSpec.describe Serega::SeregaPlan do
     end
 
     it "returns all not hidden attributes except provided in :except option" do
-      result = plan(only: {}, except: {a2: {}, d: {d1: {}}}, with: {})
+      result = plan(only: {}, except: {"a2" => {}, "d" => {"d1" => {}}}, with: {})
 
       expect(result).to satisfy_attribute_names(
         a1: nil,
@@ -84,7 +84,7 @@ RSpec.describe Serega::SeregaPlan do
     end
 
     it "returns all not hidden attributes and attributes defined in :with option" do
-      result = plan(only: {}, except: {}, with: {a3: {}, b: {}, c: {c3: {}}})
+      result = plan(only: {}, except: {}, with: {"a3" => {}, "b" => {}, "c" => {"c3" => {}}})
 
       expect(result).to satisfy_attribute_names(
         a1: nil,
@@ -99,34 +99,34 @@ RSpec.describe Serega::SeregaPlan do
 
   describe "saving plans to cache" do
     it "does not save plans to cache when not configured to do so" do
-      result1 = plan(only: {a1: {}})
-      result2 = plan(only: {a1: {}})
+      result1 = plan(only: {"a1" => {}})
+      result2 = plan(only: {"a1" => {}})
 
-      expect(result1).to satisfy_attribute_names(a1: nil)
-      expect(result2).to satisfy_attribute_names(a1: nil)
+      expect(result1).to satisfy_attribute_names("a1" => nil)
+      expect(result2).to satisfy_attribute_names("a1" => nil)
       expect(result1).not_to equal result2
     end
 
     it "saves plans to cache and uses them when configured to use cache" do
       current_serializer.config.max_cached_plans_per_serializer_count = 1
-      result1 = plan(only: {a1: {}})
-      result2 = plan(only: {a1: {}})
+      result1 = plan(only: {"a1" => {}})
+      result2 = plan(only: {"a1" => {}})
 
-      expect(result1).to satisfy_attribute_names(a1: nil)
-      expect(result2).to satisfy_attribute_names(a1: nil)
+      expect(result1).to satisfy_attribute_names("a1" => nil)
+      expect(result2).to satisfy_attribute_names("a1" => nil)
       expect(result1).to equal result2
     end
 
     it "removes from cache oldest plans if cached keys count more than configured" do
       current_serializer.config.max_cached_plans_per_serializer_count = 1
 
-      result1 = plan(only: {a1: {}})
+      result1 = plan(only: {"a1" => {}})
       plan(only: {a2: {}}) # replace cached result1
 
-      result2 = plan(only: {a1: {}})
+      result2 = plan(only: {"a1" => {}})
 
-      expect(result1).to satisfy_attribute_names(a1: nil)
-      expect(result2).to satisfy_attribute_names(a1: nil)
+      expect(result1).to satisfy_attribute_names("a1" => nil)
+      expect(result2).to satisfy_attribute_names("a1" => nil)
       expect(result1).not_to equal result2
     end
   end

--- a/spec/serega/plugins/batch/lib/plugin_extensions/preloads_spec.rb
+++ b/spec/serega/plugins/batch/lib/plugin_extensions/preloads_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Serega::SeregaPlugins::Batch do
     end
 
     it "returns no preloads by default for attributes with `batch` option" do
-      expect(user_serializer.attributes[:one].preloads).to be_nil
-      expect(user_serializer.attributes[:two].preloads).to eq({two: {}})
+      expect(user_serializer.attributes["one"].preloads).to be_nil
+      expect(user_serializer.attributes["two"].preloads).to eq({two: {}})
     end
 
     it "keeps manually added preloads" do
-      expect(user_serializer.attributes[:three].preloads).to eq({custom: {}})
+      expect(user_serializer.attributes["three"].preloads).to eq({custom: {}})
     end
   end
 end

--- a/spec/serega/plugins/camel_case/camel_case_spec.rb
+++ b/spec/serega/plugins/camel_case/camel_case_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Serega::SeregaPlugins::CamelCase do
     end
 
     context "with custom camel_case transformation" do
-      let(:base_serializer) { Class.new(Serega) { plugin :camel_case, transform: ->(name) { name.to_s.upcase! } } }
+      let(:base_serializer) { Class.new(Serega) { plugin :camel_case, transform: ->(name) { name.upcase } } }
 
       it "serializes keys transformed names" do
         response = user_serializer.new.to_h(user)

--- a/spec/serega/plugins/preloads/lib/modules/plan_point_spec.rb
+++ b/spec/serega/plugins/preloads/lib/modules/plan_point_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe Serega::SeregaPlugins::Preloads do
       point = plan_point(foo)
       expect(point.preloads).to eq({})
 
-      point = plan_point(foo, {with: {foo: {}}})
+      point = plan_point(foo, {with: {"foo" => {}}})
       expect(point.preloads).to eq({foo1: {}})
 
-      point = plan_point(foo, {with: {foo: {}, bar: {}}})
+      point = plan_point(foo, {with: {"foo" => {}, "bar" => {}}})
       expect(point.preloads).to eq({foo1: {}, bar1: {}})
 
-      point = plan_point(foo, {with: {foo: {}, bar: {foo: {}}}})
+      point = plan_point(foo, {with: {"foo" => {}, "bar" => {"foo" => {}}}})
       expect(point.preloads).to eq({foo1: {}, bar1: {foo1: {}}})
     end
   end

--- a/spec/serega/plugins/string_modifiers/parse_string_modifiers_spec.rb
+++ b/spec/serega/plugins/string_modifiers/parse_string_modifiers_spec.rb
@@ -13,35 +13,35 @@ RSpec.describe Serega::SeregaPlugins::StringModifiers::ParseStringModifiers do
     end
 
     it "parses single field" do
-      expect(parse("id")).to eq(id: {})
+      expect(parse("id")).to eq("id" => {})
     end
 
     it "parses multiple fields" do
-      expect(parse("id, name")).to eq(id: {}, name: {})
+      expect(parse("id, name")).to eq("id" => {}, "name" => {})
     end
 
     it "parses single resource with single field" do
-      expect(parse("users(id)")).to eq(users: {id: {}})
+      expect(parse("users(id)")).to eq("users" => {"id" => {}})
     end
 
     it "parses fields started with open PAREN" do
-      expect(parse("(users(id))")).to eq(users: {id: {}})
+      expect(parse("(users(id))")).to eq("users" => {"id" => {}})
     end
 
     it "parses fields started with extra close PAREN" do
-      expect(parse(")users)")).to eq(users: {})
+      expect(parse(")users)")).to eq("users" => {})
     end
 
     it "parses single resource with multiple fields" do
-      expect(parse("users(id,name)")).to eq(users: {id: {}, name: {}})
+      expect(parse("users(id,name)")).to eq("users" => {"id" => {}, "name" => {}})
     end
 
     it "parses multiple resources with fields" do
       fields = "id,posts(title,text),news(title,text)"
       resp = {
-        id: {},
-        posts: {title: {}, text: {}},
-        news: {title: {}, text: {}}
+        "id" => {},
+        "posts" => {"title" => {}, "text" => {}},
+        "news" => {"title" => {}, "text" => {}}
       }
 
       expect(parse(fields)).to eq(resp)
@@ -50,15 +50,15 @@ RSpec.describe Serega::SeregaPlugins::StringModifiers::ParseStringModifiers do
     it "parses included resources" do
       fields = "id,posts(title,text,comments(author(name),comment))"
       resp = {
-        id: {},
-        posts: {
-          title: {},
-          text: {},
-          comments: {
-            author: {
-              name: {}
+        "id" => {},
+        "posts" => {
+          "title" => {},
+          "text" => {},
+          "comments" => {
+            "author" => {
+              "name" => {}
             },
-            comment: {}
+            "comment" => {}
           }
         }
       }

--- a/spec/serega/utils/symbol_name_spec.rb
+++ b/spec/serega/utils/symbol_name_spec.rb
@@ -3,10 +3,21 @@
 RSpec.describe Serega::SeregaUtils::SymbolName do
   subject(:result) { described_class.call(val) }
 
-  let(:val) { :foo }
-
-  it "returns frozen string" do
+  it "converts symbols or non-frozen strings to frozen strings" do
+    value = :foo
+    result = described_class.call(value)
     expect(result).to eq("foo")
+    expect(result).to be_frozen
+
+    value = +"foo"
+    result = described_class.call(value)
+    expect(result).to eq("foo")
+    expect(result).not_to equal(value)
+    expect(result).to be_frozen
+
+    value = -"foo"
+    result = described_class.call(value)
+    expect(result).to equal value
     expect(result).to be_frozen
   end
 end

--- a/spec/serega/utils/to_stringified_hash_spec.rb
+++ b/spec/serega/utils/to_stringified_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Serega::SeregaUtils::ToHash do
+RSpec.describe Serega::SeregaUtils::ToStringifiedHash do
   subject(:result) { described_class.call(val) }
 
   context "with nil value" do
@@ -25,9 +25,9 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { %w[foo bar] }
 
     it "returns hash with symbol keys and frozen empty hash values" do
-      expect(result).to eq(foo: {}, bar: {})
-      expect(result[:foo]).to be_frozen
-      expect(result[:bar]).to be_frozen
+      expect(result).to eq("foo" => {}, "bar" => {})
+      expect(result["foo"]).to be_frozen
+      expect(result["bar"]).to be_frozen
     end
   end
 
@@ -43,8 +43,8 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { :foo }
 
     it "returns hash with frozen empty hash value" do
-      expect(result).to eq(foo: {})
-      expect(result[:foo]).to be_frozen
+      expect(result).to eq("foo" => {})
+      expect(result["foo"]).to be_frozen
     end
   end
 
@@ -52,8 +52,8 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { "foo" }
 
     it "returns hash with symbol key and frozen empty hash value" do
-      expect(result).to eq(foo: {})
-      expect(result[:foo]).to be_frozen
+      expect(result).to eq("foo" => {})
+      expect(result["foo"]).to be_frozen
     end
   end
 
@@ -61,16 +61,8 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { {foo: :bar} }
 
     it "returns nested hash with frozen empty hash final value" do
-      expect(result).to eq(foo: {bar: {}})
-      expect(result[:foo][:bar]).to be_frozen
-    end
-  end
-
-  context "with empty hash value" do
-    let(:val) { {} }
-
-    it "returns empty hash" do
-      expect(result).to equal(Serega::FROZEN_EMPTY_HASH)
+      expect(result).to eq("foo" => {"bar" => {}})
+      expect(result["foo"]["bar"]).to be_frozen
     end
   end
 
@@ -78,8 +70,8 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     let(:val) { {"foo" => "bar"} }
 
     it "returns nested hash with symbol keys with frozen empty hash final value" do
-      expect(result).to eq(foo: {bar: {}})
-      expect(result[:foo][:bar]).to be_frozen
+      expect(result).to eq("foo" => {"bar" => {}})
+      expect(result["foo"]["bar"]).to be_frozen
     end
   end
 
@@ -91,20 +83,21 @@ RSpec.describe Serega::SeregaUtils::ToHash do
     end
   end
 
+
   context "with complex value test" do
     let(:val) { [:a, "b", {c: {"d" => [:e, "f"]}}] }
 
-    it "returns nested hash with symbol keys" do
+    it "returns nested hash" do
       expect(result).to eq(
-        a: {},
-        b: {},
-        c: {d: {e: {}, f: {}}}
+        "a" => {},
+        "b" => {},
+        "c" => {"d" => {"e" => {}, "f" => {}}}
       )
 
-      expect(result.dig(:a)).to be_frozen
-      expect(result.dig(:b)).to be_frozen
-      expect(result.dig(:c, :d, :e)).to be_frozen
-      expect(result.dig(:c, :d, :f)).to be_frozen
+      expect(result.dig("a")).to be_frozen
+      expect(result.dig("b")).to be_frozen
+      expect(result.dig("c", "d", "e")).to be_frozen
+      expect(result.dig("c", "d", "f")).to be_frozen
     end
   end
 end


### PR DESCRIPTION
By default all 'to_h' methods will generate hash with symbol keys, as before By default all 'to_json' methods will firstly generate hash with string keys, as transforming them to JSON should be faster.