### PR TITLE
Replace config.auto_hide with config.hide_by_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+- Replace `config.auto_hide` with `config.hide_by_default`.
+  Accepts `false` (default — nothing hidden), `true` (hide all attributes),
+  or an array of symbols — `[:preload]`, `[:batch]`, or `[:preload, :batch]` —
+  to hide only attributes that use those options.
+  Attribute-level `hide: true/false` always takes precedence over the config.
+
 ## [0.33.2] - 2026-04-05
 
 - Allow `true` as a modifier value (e.g. `only: { users: { first_name: true, posts: { text: true } } }`)

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Serega includes built-in batch loading functionality to efficiently load data on
 
 #### Defining Named Batch Loaders
 
-Named loaders can be defined using the `batch_loader` class method and reused across attributes:
+Named loaders can be defined using the `batch` class method and reused across attributes:
 
 ```ruby
 class UserSerializer < Serega
@@ -385,10 +385,14 @@ class AppSerializer < Serega
   # It helps to preload associations automatically, omitting N+1 requests.
   config.auto_preload = false
 
-  # Automatically marks as hidden attributes with `:preload` or `:batch` options.
-  # By default is false. Useful option to not make extra DB requests if attribute
-  # was not requested
-  config.auto_hide = false
+  # Hides attributes by default. Accepts:
+  #   false         - nothing hidden (default)
+  #   true          - all attributes hidden
+  #   [:preload]    - attributes with :preload option hidden
+  #   [:batch]      - attributes with :batch option hidden
+  #   [:preload, :batch] - either option triggers hiding
+  # Useful to avoid extra DB requests for attributes that were not requested.
+  config.hide_by_default = false
 
   # Default method used on serialized object to resolve batch value
   # For example:
@@ -418,9 +422,8 @@ into a single associations hash.
 
 Configuration options:
 
-- `config.auto_preload_attributes_with_delegate` - default `false`
-- `config.auto_preload_attributes_with_serializer` - default `false`
-- `config.auto_hide_attributes_with_preload` - default `false`
+- `config.auto_preload` - default `false` (use `true` or `{ has_delegate_option: true, has_serializer_option: true }`)
+- `config.hide_by_default` - default `false` (use `[:preload]` to hide attributes with preloads)
 
 These options are extremely useful if you want to forget about finding
 preloads manually.
@@ -433,9 +436,8 @@ For some examples, **please read the comments in the code below**
 
 ```ruby
 class AppSerializer < Serega
-  config.auto_preload_attributes_with_delegate = true
-  config.auto_preload_attributes_with_serializer = true
-  config.auto_hide_attributes_with_preload = true
+  config.auto_preload = true
+  config.hide_by_default = [:preload]
 end
 
 class UserSerializer < AppSerializer
@@ -447,11 +449,11 @@ class UserSerializer < AppSerializer
     value: proc { |user| user.user_stats.followers_count }
 
   # `preload: :user_stats` added automatically, as
-  # `auto_preload_attributes_with_delegate` option is true
+  # `auto_preload` includes `has_delegate_option: true`
   attribute :comments_count, delegate: { to: :user_stats }
 
   # `preload: :albums` added automatically as
-  # `auto_preload_attributes_with_serializer` option is true
+  # `auto_preload` includes `has_serializer_option: true`
   attribute :albums, serializer: 'AlbumSerializer'
 end
 
@@ -459,7 +461,7 @@ class AlbumSerializer < AppSerializer
   attribute :images_count, delegate: { to: :album_stats }
 end
 
-# By default, preloads are empty, as we specify `auto_hide_attributes_with_preload`
+# By default, preloads are empty, as we specify `hide_by_default = [:preload]`
 # so attributes with preloads will be skipped and nothing will be preloaded
 UserSerializer.new.preloads
 # => {}
@@ -487,10 +489,8 @@ other user associations. You should specify `preload: nil` to preload
 
 ```ruby
 class AppSerializer < Serega
-  plugin :preloads,
-    auto_preload_attributes_with_delegate: true,
-    auto_preload_attributes_with_serializer: true,
-    auto_hide_attributes_with_preload: true
+  config.auto_preload = true
+  config.hide_by_default = [:preload]
 end
 
 class UserSerializer < AppSerializer
@@ -511,9 +511,7 @@ achieve this:
 
 ```ruby
 class AppSerializer < Serega
-  plugin :preloads,
-    auto_preload_attributes_with_delegate: true,
-    auto_preload_attributes_with_serializer: true
+  config.auto_preload = true
 end
 
 class UserSerializer < AppSerializer
@@ -570,9 +568,8 @@ uses ActiveRecord::Associations::Preloader to preload associations to objects.
 
 ```ruby
 class AppSerializer < Serega
-  config.auto_preload_attributes_with_delegate = true
-  config.auto_preload_attributes_with_serializer = true
-  config.auto_hide_attributes_with_preload = false
+  config.auto_preload = true
+  config.hide_by_default = false
 
   plugin :activerecord_preloads
 end

--- a/examples/preloads.rb
+++ b/examples/preloads.rb
@@ -77,7 +77,7 @@ class AppSerializer < Serega
   plugin :activerecord_preloads
 
   config.auto_preload = true
-  config.auto_hide = false
+  config.hide_by_default = false
 end
 
 class UserSerializer < AppSerializer

--- a/lib/serega/attribute_normalizer.rb
+++ b/lib/serega/attribute_normalizer.rb
@@ -153,18 +153,18 @@ class Serega
       end
 
       def prepare_hide
-        # Return provided durectly value
+        # Return provided directly value
         hide = init_opts[:hide]
         return hide if (hide == true) || (hide == false)
 
-        # Auto hide when `:preload` option provided
-        if config.auto_hide.fetch(:has_preload_option)
-          return true if preloads
-        end
+        hide_setting = config.hide_by_default
 
-        # Auto hide when `:batch` option provided
-        if config.auto_hide.fetch(:has_batch_option)
-          return true if batch_loaders.any?
+        case hide_setting
+        when true
+          return true
+        when Array
+          return true if hide_setting.include?(:preload) && preloads # hide when attribute has `:preload` option
+          return true if hide_setting.include?(:batch) && batch_loaders.any? # hide when attribute has `:batch` option
         end
 
         # Return nil for undefined value which means "not hide" but allows

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -32,7 +32,7 @@ class Serega
       delegate_default_allow_nil: false,
       max_cached_plans_per_serializer_count: 0,
       auto_preload: {has_delegate_option: false, has_serializer_option: false},
-      auto_hide: {has_preload_option: false, has_batch_option: false},
+      hide_by_default: false,
       batch_id_option: :id
     }.freeze
     # :nocov:
@@ -115,23 +115,28 @@ class Serega
         opts[:delegate_default_allow_nil] = value
       end
 
-      # @return [Hash] auto_hide option
-      def auto_hide
-        opts.fetch(:auto_hide)
+      # Returns :hide_by_default config option
+      # @return [Boolean, Array<Symbol>] Current :hide_by_default config option
+      def hide_by_default
+        opts.fetch(:hide_by_default)
       end
 
-      # Validates and sets auto_hide option
-      # @return [Hash] New auto_hide option with attributes that trigger auto hide
-      def auto_hide=(value)
-        opts[:auto_hide] =
+      # Sets :hide_by_default config option
+      #
+      # @param value [Boolean, Array<Symbol>] false, true, or array of :preload/:batch symbols
+      #
+      # @return [Boolean, Array<Symbol>] New :hide_by_default config option
+      def hide_by_default=(value)
+        opts[:hide_by_default] =
           case value
-          when true then {has_preload_option: true, has_batch_option: true}
-          when false then {has_preload_option: false, has_batch_option: false}
-          when Hash
-            SeregaValidations::Utils::CheckAllowedKeys.call(value, %i[has_preload_option has_batch_option], "auto_hide")
-            {has_preload_option: !!value[:has_preload_option], has_batch_option: !!value[:has_batch_option]}
+          when true, false
+            value
+          when Array
+            invalid = value - %i[preload batch]
+            raise SeregaError, "Must have true, false, or an Array of [:preload, :batch], #{value.inspect} provided" if invalid.any?
+            value
           else
-            raise SeregaError, "Must have boolean value or Hash, #{value.inspect} provided"
+            raise SeregaError, "Must have true, false, or an Array of [:preload, :batch], #{value.inspect} provided"
           end
       end
 

--- a/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
+++ b/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
@@ -15,7 +15,7 @@ class Serega
     #   class AppSerializer < Serega
     #     config.auto_preload_attributes_with_delegate = true
     #     config.auto_preload_attributes_with_serializer = true
-    #     config.auto_hide_attributes_with_preload = true
+    #     config.hide_by_default = [:preload]
     #
     #     plugin :activerecord_preloads
     #   end

--- a/spec/serega/attribute_normalizer_spec.rb
+++ b/spec/serega/attribute_normalizer_spec.rb
@@ -78,22 +78,22 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
     context "with :preload option" do
       subject(:hide) { normalizer.new(opts: {preload: :foo}).hide }
 
-      it "returns nil if `auto_hide[:has_preload_option]` setting is not set" do
+      it "returns nil if `hide_by_default` is not set" do
         expect(hide).to be_nil
       end
 
-      it "returns true if `auto_hide[:has_preload_option]` is set to true" do
-        serializer_class.config.auto_hide = {has_preload_option: true}
+      it "returns true if `hide_by_default` includes :preload" do
+        serializer_class.config.hide_by_default = [:preload]
         expect(hide).to be true
       end
 
-      it "returns nil if `auto_hide[:has_preload_option]` is set to false" do
-        serializer_class.config.auto_hide = {has_batch_option: true}
+      it "returns nil if `hide_by_default` does not include :preload" do
+        serializer_class.config.hide_by_default = [:batch]
         expect(hide).to be_nil
       end
 
-      it "returns nil if `auto_hide[:has_preload_option]` is set to true and no preloads" do
-        serializer_class.config.auto_hide = {has_preload_option: true}
+      it "returns nil if `hide_by_default` includes :preload but attribute has no preloads" do
+        serializer_class.config.hide_by_default = [:preload]
         expect(normalizer.new(opts: {}).hide).to be_nil
       end
     end
@@ -101,24 +101,41 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
     context "with :batch option" do
       subject(:hide) { normalizer.new(name: :foo, opts: {batch: true}).hide }
 
-      it "returns nil if `hide_batch_attributes` setting is not set" do
+      it "returns nil if `hide_by_default` is not set" do
         expect(hide).to be_nil
       end
 
-      it "returns true if `hide_batch_attributes` is set to true" do
-        serializer_class.config.auto_hide = {has_batch_option: true}
+      it "returns true if `hide_by_default` includes :batch" do
+        serializer_class.config.hide_by_default = [:batch]
         expect(hide).to be true
       end
 
-      it "returns nil if `hide_batch_attributes` is set to false" do
-        serializer_class.config.auto_hide = {has_batch_option: false}
+      it "returns nil if `hide_by_default` does not include :batch" do
+        serializer_class.config.hide_by_default = [:preload]
         expect(hide).to be_nil
       end
 
-      it "returns nil if `hide_batch_attributes` is set to true and no or empty batch option" do
-        serializer_class.config.auto_hide = {has_batch_option: true}
+      it "returns nil if `hide_by_default` includes :batch but no or empty batch option" do
+        serializer_class.config.hide_by_default = [:batch]
         expect(normalizer.new(opts: {}).hide).to be_nil
         expect(normalizer.new(opts: {batch: {use: []}}).hide).to be_nil
+      end
+    end
+
+    context "with hide_by_default: true" do
+      it "returns true for any attribute without explicit hide option" do
+        serializer_class.config.hide_by_default = true
+        expect(normalizer.new(opts: {}).hide).to be true
+      end
+
+      it "returns true for explicit hide: true" do
+        serializer_class.config.hide_by_default = true
+        expect(normalizer.new(opts: {hide: true}).hide).to be true
+      end
+
+      it "returns false for explicit hide: false — attribute-level wins over config" do
+        serializer_class.config.hide_by_default = true
+        expect(normalizer.new(opts: {hide: false}).hide).to be false
       end
     end
   end

--- a/spec/serega/config_spec.rb
+++ b/spec/serega/config_spec.rb
@@ -54,36 +54,42 @@ RSpec.describe Serega::SeregaConfig do
     end
   end
 
-  describe "#auto_hide" do
+  describe "#hide_by_default" do
     it "returns default value" do
-      expect(config.auto_hide).to eq(has_preload_option: false, has_batch_option: false)
+      expect(config.hide_by_default).to be false
     end
   end
 
-  describe "#auto_hide=" do
-    it "validates value is boolean" do
-      expect { config.auto_hide = false }.not_to raise_error
-      expect { config.auto_hide = true }.not_to raise_error
-      expect { config.auto_hide = nil }
-        .to raise_error Serega::SeregaError, "Must have boolean value or Hash, nil provided"
-
-      expect { config.auto_hide = {foo: :bar} }
+  describe "#hide_by_default=" do
+    it "validates value" do
+      expect { config.hide_by_default = false }.not_to raise_error
+      expect { config.hide_by_default = true }.not_to raise_error
+      expect { config.hide_by_default = [:preload] }.not_to raise_error
+      expect { config.hide_by_default = [:batch] }.not_to raise_error
+      expect { config.hide_by_default = [:preload, :batch] }.not_to raise_error
+      expect { config.hide_by_default = nil }
         .to raise_error Serega::SeregaError,
-          "Invalid auto_hide option :foo. Allowed options are: :has_batch_option, :has_preload_option"
+          "Must have true, false, or an Array of [:preload, :batch], nil provided"
+      expect { config.hide_by_default = [:foo] }
+        .to raise_error Serega::SeregaError,
+          "Must have true, false, or an Array of [:preload, :batch], [:foo] provided"
     end
 
-    it "sets auto_hide option" do
-      config.auto_hide = true
-      expect(config.auto_hide).to eq(has_preload_option: true, has_batch_option: true)
+    it "sets hide_by_default option" do
+      config.hide_by_default = true
+      expect(config.hide_by_default).to be true
 
-      config.auto_hide = false
-      expect(config.auto_hide).to eq(has_preload_option: false, has_batch_option: false)
+      config.hide_by_default = false
+      expect(config.hide_by_default).to be false
 
-      config.auto_hide = {has_preload_option: true}
-      expect(config.auto_hide).to eq(has_preload_option: true, has_batch_option: false)
+      config.hide_by_default = [:preload]
+      expect(config.hide_by_default).to eq [:preload]
 
-      config.auto_hide = {has_batch_option: true}
-      expect(config.auto_hide).to eq(has_preload_option: false, has_batch_option: true)
+      config.hide_by_default = [:batch]
+      expect(config.hide_by_default).to eq [:batch]
+
+      config.hide_by_default = [:preload, :batch]
+      expect(config.hide_by_default).to eq [:preload, :batch]
     end
   end
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Serega do
         delegate_default_allow_nil
         max_cached_plans_per_serializer_count
         auto_preload
-        auto_hide
+        hide_by_default
         batch_id_option
       ]
 
@@ -47,7 +47,7 @@ RSpec.describe Serega do
       expect(config.check_initiate_params).to be true
       expect(config.delegate_default_allow_nil).to be false
       expect(config.max_cached_plans_per_serializer_count).to eq 0
-      expect(config.auto_hide).to eq(has_batch_option: false, has_preload_option: false)
+      expect(config.hide_by_default).to be false
       expect(config.auto_preload).to eq(has_delegate_option: false, has_serializer_option: false)
       expect(config.batch_id_option).to eq :id
     end
@@ -663,7 +663,7 @@ RSpec.describe Serega do
       end
 
       it "auto-hides attributes with preloads when configured" do
-        serializer_class.config.auto_hide = {has_preload_option: true}
+        serializer_class.config.hide_by_default = [:preload]
         serializer_class.attribute :name, preload: :user_profile
         attribute = serializer_class.attributes[:name]
         expect(attribute.hide).to be true


### PR DESCRIPTION
Accepts false (default), true (hide all), or an array of symbols (:preload, :batch) to hide only attributes that use those options. Attribute-level hide: true/false always takes precedence over the config.