### PR TITLE
Add context access inside Presenter via __ctx__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Plugin `:presenter` — expose serialization context inside `Presenter` via `__ctx__`
+
 ## [0.34.0] - 2026-04-29
 
 - Replace `config.auto_hide` with `config.hide_by_default`.

--- a/README.md
+++ b/README.md
@@ -761,26 +761,49 @@ end
 
 ### Plugin :presenter
 
-Helps to write clean code by using a Presenter class.
+Moves computed attribute logic out of blocks and into a dedicated `Presenter` class,
+keeping serializers readable as schemas rather than bags of lambdas.
+
+Without the plugin, computed attributes live as inline blocks:
+
+```ruby
+class UserSerializer < Serega
+  attribute :name, value: proc { |u| [u.first_name, u.last_name].compact.join(' ') }
+  attribute :role, value: proc { |u, ctx| u == ctx[:current_user] ? :self : :other }
+end
+```
+
+With the plugin, they move into a clean class:
 
 ```ruby
 class UserSerializer < Serega
   plugin :presenter
 
   attribute :name
-  attribute :address
+  attribute :role
 
   class Presenter
     def name
-      [first_name, last_name].compact_blank.join(' ')
+      [first_name, last_name].compact.join(' ')
     end
 
-    def address
-      [country, city, address].join("\n")
+    def role
+      id == __ctx__[:current_user_id] ? :self : :other
     end
   end
 end
 ```
+
+`Presenter` inherits from `SimpleDelegator`, so every method of the serialized
+object is available directly inside presenter methods. Any method not explicitly
+defined on `Presenter` is resolved via `method_missing` on the first call, which
+also defines a real delegator method — so all subsequent serializations call it
+directly, without going through `method_missing` again.
+
+The original wrapped object is accessible via `__getobj__` (standard
+`SimpleDelegator` API) when you need an unambiguous reference to it.
+
+The serialization context is accessible via the private method `__ctx__`.
 
 ### Plugin :string_modifiers
 

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -6,16 +6,28 @@ require "forwardable"
 class Serega
   module SeregaPlugins
     #
-    # Plugin Presenter adds possibility to use declare Presenter for your objects inside serializer
+    # Plugin :presenter — moves computed attribute logic into a dedicated Presenter class.
     #
-    #   class User < Serega
+    # Presenter inherits from SimpleDelegator:
+    # - All methods of the serialized object are available directly inside presenter methods.
+    # - Methods not defined on Presenter are resolved via method_missing on the first call
+    #   and then defined as real delegators, so subsequent calls skip method_missing entirely.
+    # - The original object is accessible via __getobj__ (standard SimpleDelegator API).
+    # - The serialization context is accessible via the private method __ctx__.
+    #
+    #   class UserSerializer < Serega
     #     plugin :presenter
     #
     #     attribute :name
+    #     attribute :role
     #
     #     class Presenter
     #       def name
-    #         [first_name, last_name].compact_blank.join(' ')
+    #         [first_name, last_name].compact.join(' ') # first_name/last_name delegated to object
+    #       end
+    #
+    #       def role
+    #         id == __ctx__[:current_user_id] ? :self : :other
     #       end
     #     end
     #   end
@@ -56,6 +68,15 @@ class Serega
       class Presenter < SimpleDelegator
         # Presenter instance methods
         module InstanceMethods
+          def initialize(object, ctx = nil)
+            super(object)
+            @__ctx__ = ctx
+          end
+
+          private
+
+          attr_reader :__ctx__
+
           #
           # Delegates all missing methods to serialized object.
           #
@@ -100,10 +121,10 @@ class Serega
         private
 
         #
-        # Replaces serialized object with Presenter.new(object)
+        # Replaces serialized object with Presenter.new(object, ctx)
         #
         def serialize_object(object)
-          object = self.class.serializer_class::Presenter.new(object)
+          object = self.class.serializer_class::Presenter.new(object, context)
           super
         end
       end

--- a/spec/serega/plugins/presenter/presenter_spec.rb
+++ b/spec/serega/plugins/presenter/presenter_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
     expect(result).to eq([{value: 123}, {value: 234}])
   end
 
+  it "makes __ctx__ private" do
+    expect(serializer::Presenter.private_method_defined?(:__ctx__)).to be true
+  end
+
+  it "exposes context inside Presenter via __ctx__" do
+    serializer.attribute(:greeting) { |obj| obj.greeting }
+    serializer::Presenter.class_exec do
+      def greeting
+        "Hello, #{__ctx__[:name]}!"
+      end
+    end
+
+    result = serializer.new.to_h("ignored", context: {name: "Alice"})
+    expect(result).to eq({greeting: "Hello, Alice!"})
+  end
+
   it "works in nested relation" do
     struct = Struct.new(:nested).new("123")
 


### PR DESCRIPTION
- Presenter#initialize now accepts context and exposes it via private __ctx__
- serialize_object passes context when constructing the Presenter
- Update README and plugin docs with before/after example and full explanation
- Add CHANGELOG entry