### PR TITLE
Batch load once per plan level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   chains keep the same query counts. `config.hide_by_default = :auto` hides the
   same attributes as before (those declared with `:preload` or `:batch`).
 
+- Fixed: a named batch loader shared by several attributes (`batch: { use: :name }`)
+  is now called once per object set instead of once per attribute.
+
 - Add the `preload_with` serializer class method — register a handler (a block or
   a callable taking `(objects, preloads)`) that performs the eager loading for
   attributes declared with `:preload`. This is the generic loading seam: the
@@ -61,11 +64,6 @@
   a `preload_with` handler on that serializer. If none is registered, serializing
   raises a clear error instead of silently preloading nothing. Loading
   `:activerecord_preloads` registers the handler for you.
-
-- Fix `:presenter` + `:activerecord_preloads`: associations now preload onto the
-  underlying records instead of the presenter wrappers. The `:presenter` plugin
-  must be loaded after `:activerecord_preloads` (loading them in the wrong order
-  now raises a clear error).
 
 ## [0.36.0] - 2026-05-12
 

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -32,6 +32,7 @@ require_relative "serega/attribute"
 require_relative "serega/attribute_normalizer"
 require_relative "serega/batch/attribute_loader"
 require_relative "serega/batch/attribute_loaders"
+require_relative "serega/batch/level"
 require_relative "serega/batch/loader"
 require_relative "serega/validations/utils/check_allowed_keys"
 require_relative "serega/validations/utils/check_opt_is_bool"
@@ -479,7 +480,7 @@ class Serega
       self.class::CheckSerializeParams.new(opts).validate unless opts.empty?
 
       opts[:context] ||= {}
-      opts[:batch_loaders] = SeregaBatch::AttributeLoaders.new
+      opts[:batch_loaders] = SeregaBatch::AttributeLoaders.new(opts[:context])
       opts[:many] = object.is_a?(Enumerable) unless opts.key?(:many)
       opts[:plan] = plan
       opts
@@ -491,7 +492,7 @@ class Serega
     # - plugin :metadata (adds metadata to final result)
     def serialize(object, opts)
       result = self.class::SeregaObjectSerializer.new(**opts).serialize(object)
-      opts[:batch_loaders].load_all(opts[:context])
+      opts[:batch_loaders].load_all
       result
     end
   end

--- a/lib/serega/batch/attribute_loader.rb
+++ b/lib/serega/batch/attribute_loader.rb
@@ -10,9 +10,10 @@ class Serega
       # Instance methods for AttributeLoader
       module InstanceMethods
         # @param point [SeregaPlanPoint]
-        def initialize(point)
+        # @param level [SeregaBatch::Level] Shared objects and results for this point's plan level
+        def initialize(point, level)
           @point = point
-          @objects = []
+          @level = level
           @serialized_object_attachers = []
         end
 
@@ -21,50 +22,51 @@ class Serega
         # @param attacher [Proc] Proc that attaches found values to originated attributes
         # @return [void]
         def store(object, attacher)
-          objects << object
           serialized_object_attachers << [object, attacher]
         end
 
-        # Loads serialized values for all stored objects for current attribute
-        # @param context [Hash] Current serialization context
+        # Preloads this attribute's associations onto the level's objects, once for
+        # the attribute (not per named batch loader), via the serializer's registered
+        # `preload_with` handler. Raises when `:preload` is declared but no handler
+        # exists, so a declared preload never silently does nothing.
         # @return [void]
-        def load_all(context)
-          batches = {}
-          serializer_class = point.class.serializer_class
+        def preload_associations
+          preloads = point.attribute.preloads
+          return unless preloads
 
-          point.batch_loaders.each do |batch_loader_name|
-            batches[batch_loader_name] ||= load_one(serializer_class, batch_loader_name, context)
+          handler = point.class.serializer_class.preload_with
+          unless handler
+            raise SeregaError, "The :preload option requires a preload handler. Register one with `preload_with` (the :activerecord_preloads plugin does this for you)."
           end
 
+          handler.call(level.objects, preloads)
+        rescue => error
+          reraise_with_serialized_attribute_details(error)
+        end
+
+        # Loads a single named batch for this level's objects. Caching across
+        # attributes that reuse the loader is handled by the Level.
+        # @param loader [SeregaBatch::Loader] Named batch loader
+        # @return [Object] Loaded batch values
+        def load_batch(loader)
+          level.load(loader)
+        rescue => error
+          reraise_with_serialized_attribute_details(error)
+        end
+
+        # Attaches already loaded batch values to every stored object.
+        # @param batches [Hash] Loaded values grouped by batch loader name
+        # @return [void]
+        def attach(batches)
           serialized_object_attachers.each do |object, attacher|
             attacher.call(object, batches)
           end
         end
 
+        attr_reader :point
+        attr_reader :level
+
         private
-
-        def load_one(serializer_class, batch_loader_name, context)
-          preload_attribute_associations(serializer_class)
-          serializer_class.batch_loaders[batch_loader_name].load(objects, context)
-        rescue => error
-          reraise_with_serialized_attribute_details(error)
-        end
-
-        # Runs the serializer's registered `preload_with` handler to load this
-        # attribute's associations onto the gathered records before the batch
-        # loader runs. Raises when `:preload` is declared but no handler exists,
-        # so a declared preload never silently does nothing.
-        def preload_attribute_associations(serializer_class)
-          preloads = point.attribute.preloads
-          return unless preloads
-
-          handler = serializer_class.preload_with
-          unless handler
-            raise SeregaError, "The :preload option requires a preload handler. Register one with `preload_with` (the :activerecord_preloads plugin does this for you)."
-          end
-
-          handler.call(objects, preloads)
-        end
 
         def reraise_with_serialized_attribute_details(error)
           raise error.exception(<<~MESSAGE.strip)
@@ -73,8 +75,6 @@ class Serega
           MESSAGE
         end
 
-        attr_reader :point
-        attr_reader :objects
         attr_reader :serialized_object_attachers
       end
 

--- a/lib/serega/batch/attribute_loaders.rb
+++ b/lib/serega/batch/attribute_loaders.rb
@@ -13,9 +13,24 @@ class Serega
       #
       # Initializes new batch loaders
       #
-      def initialize
-        @point_batch_loaders = []
+      # @param context [Hash] Serialization context, constant for the whole run
+      #
+      def initialize(context)
+        @context = context
+        @attribute_loaders = []
         @point_index = {}.compare_by_identity
+        @levels = {}.compare_by_identity
+      end
+
+      # Gathers a chunk of objects serialized at a plan level, so every attribute at
+      # that level shares one set of objects to batch load against.
+      #
+      # @param plan [SeregaPlan] Plan serializing these objects
+      # @param objects [Array] Objects being serialized at this level
+      #
+      # @return [void]
+      def add_objects(plan, objects)
+        level_for(plan).add_objects(objects)
       end
 
       # Remembers data for batch serialization:
@@ -26,38 +41,68 @@ class Serega
       #
       # @return [void]
       def remember(point, object, attacher)
-        point_batch_loader = point_index[point]
+        attribute_loader = point_index[point]
 
-        unless point_batch_loader
+        unless attribute_loader
           serializer_class = point.class.serializer_class
-          point_batch_loader = serializer_class::SeregaBatchAttributeLoader.new(point)
-          point_batch_loaders << point_batch_loader
-          point_index[point] = point_batch_loader
+          attribute_loader = serializer_class::SeregaBatchAttributeLoader.new(point, level_for(point.plan))
+          attribute_loaders << attribute_loader
+          point_index[point] = attribute_loader
         end
 
-        point_batch_loader.store(object, attacher)
+        attribute_loader.store(object, attacher)
       end
 
       #
-      # Loads all registered batches and removes them from registered list
+      # Loads all registered batches and attaches loaded values.
       #
       # Iterates over each loader including loaders added during iteration
       # (child serializers discovered inside a batch flush add new loaders).
-      def load_all(context)
+      def load_all
         i = 0
-        while i < point_batch_loaders.size
-          point_batch_loaders[i].load_all(context)
+        while i < attribute_loaders.size
+          attribute_loader = attribute_loaders[i]
+          attribute_loader.attach(load_batches(attribute_loader))
           i += 1
         end
       end
 
       private
 
-      # keeps all point_batch_loaders list
-      attr_reader :point_batch_loaders
+      # Serialization context shared by every level
+      attr_reader :context
 
-      # keeps tracking of already added serializers
+      # keeps all AttributeLoader instances
+      attr_reader :attribute_loaders
+
+      # keeps tracking of already added points
       attr_reader :point_index
+
+      # keeps one Level per plan (compare_by_identity: plan instance identifies a level)
+      attr_reader :levels
+
+      def level_for(plan)
+        levels[plan] ||= Level.new(context)
+      end
+
+      # Builds the { batch_loader_name => loaded_values } hash for one attribute.
+      #
+      # Loading is delegated to the attribute's Level, which loads each named batch
+      # once for the whole level: attributes sharing a loader over the same objects
+      # reuse a single result, deeper levels load separately.
+      def load_batches(attribute_loader)
+        attribute_loader.preload_associations
+
+        point = attribute_loader.point
+        serializer_class = point.class.serializer_class
+
+        batches = {}
+        point.batch_loaders.each do |batch_loader_name|
+          loader = serializer_class.batch_loaders[batch_loader_name]
+          batches[batch_loader_name] = attribute_loader.load_batch(loader)
+        end
+        batches
+      end
     end
   end
 end

--- a/lib/serega/batch/level.rb
+++ b/lib/serega/batch/level.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Serega
+  #
+  # Batch feature main module
+  #
+  module SeregaBatch
+    #
+    # Objects serialized at one plan level, together with their loaded batch results.
+    #
+    # Every attribute serialized at the same level shares one Level, so a named batch
+    # loader reused by several of them runs once for the whole set of objects. The same
+    # loader over a different level (deeper nesting) uses a different Level and loads
+    # again.
+    #
+    class Level
+      # @return [Array] Objects gathered for this level
+      attr_reader :objects
+
+      # @param context [Hash] Serialization context
+      def initialize(context)
+        @context = context
+        @objects = []
+        @results = {}.compare_by_identity
+      end
+
+      # Adds a chunk of serialized objects to this level.
+      # @param objects [Array] Objects being serialized at this level
+      # @return [void]
+      def add_objects(objects)
+        @objects.concat(objects)
+      end
+
+      # Loads and returns values for the given batch loader, once per loader.
+      #
+      # Freezes the gathered objects on the first load: all of a level's objects
+      # are added before any of its batches load, so sealing the set here guards
+      # against a later stray `add_objects` and against a loader mutating it.
+      #
+      # @param loader [SeregaBatch::Loader] Named batch loader
+      # @return [Object] Loaded values
+      def load(loader)
+        @objects.freeze
+        @results[loader] ||= loader.load(@objects, @context)
+      end
+    end
+  end
+end

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -34,7 +34,13 @@ class Serega
       def serialize(object)
         return if object.nil?
 
-        array?(object, many) ? serialize_array(object) : serialize_object(object)
+        if array?(object, many)
+          batch_loaders.add_objects(plan, object.to_a) if plan.batch?
+          serialize_array(object)
+        else
+          batch_loaders.add_objects(plan, [object]) if plan.batch?
+          serialize_object(object)
+        end
       end
 
       private

--- a/lib/serega/plan.rb
+++ b/lib/serega/plan.rb
@@ -108,6 +108,15 @@ class Serega
         self.class.serializer_class
       end
 
+      #
+      # @return [Boolean] whether any point of this plan is batch loaded
+      #
+      def batch?
+        return @batch if defined?(@batch)
+
+        @batch = points.any?(&:batch?)
+      end
+
       # Returns the Data class whose members match this plan's serialized fields.
       # Delegates to the class-level cache so identical field sets share one Data class.
       #

--- a/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
+++ b/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
@@ -59,12 +59,6 @@ class Serega
         opts.each_key do |key|
           raise SeregaError, "Plugin #{plugin_name.inspect} does not accept the #{key.inspect} option. No options are allowed"
         end
-
-        # The :presenter plugin patches preloading to unwrap presenter objects, so
-        # it must be loaded after this plugin.
-        if serializer_class.plugin_used?(:presenter)
-          raise SeregaError, "Plugin #{plugin_name.inspect} must be loaded before the :presenter plugin. Please load the #{plugin_name.inspect} plugin first"
-        end
       end
 
       #

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -62,28 +62,6 @@ class Serega
         presenter_class = Class.new(Presenter)
         presenter_class.serializer_class = serializer_class
         serializer_class.const_set(:Presenter, presenter_class)
-
-        wrap_preload_handler(serializer_class)
-      end
-
-      #
-      # Wraps the registered preload handler so associations are preloaded onto
-      # the underlying records instead of the presenter wrappers.
-      #
-      # The handler is registered by ORM plugins such as :activerecord_preloads,
-      # which must therefore be loaded before :presenter.
-      #
-      # @param serializer_class [Class<Serega>] Current serializer class
-      #
-      # @return [void]
-      #
-      def self.wrap_preload_handler(serializer_class)
-        handler = serializer_class.preload_with
-        return unless handler
-
-        serializer_class.preload_with do |objects, preloads|
-          handler.call(objects.map(&:__getobj__), preloads)
-        end
       end
 
       # Presenter class

--- a/spec/serega/batch/attribute_loader_spec.rb
+++ b/spec/serega/batch/attribute_loader_spec.rb
@@ -2,57 +2,58 @@
 
 RSpec.describe Serega::SeregaBatch do
   describe Serega::SeregaBatch::AttributeLoader do
-    subject(:loader) { described_class.new(point) }
+    subject(:attribute_loader) { described_class.new(point, level) }
 
     let(:point) { double(class: double(serializer_class: serializer_class), attribute: double(preloads: nil)) }
-    let(:serializer_class) { double(batch_loaders: batch_loaders) }
-    let(:batch_loaders) { {user: batch_loader} }
-    let(:batch_loader) { double(load: batch_data) }
+    let(:serializer_class) { double }
+    let(:level) { instance_double(Serega::SeregaBatch::Level) }
+    let(:batch_loader) { double }
     let(:batch_data) { {1 => "John", 2 => "Jane"} }
 
     describe "#store" do
-      let(:serializer) { double(__send__: nil) }
       let(:object) { double }
-      let(:container) { double }
 
-      it "adds objects and attachers to collection" do
-        loader.store(object, "attacher")
-        expect(loader.send(:objects)).to eq([object])
-        expect(loader.send(:serialized_object_attachers)).to eq [[object, "attacher"]]
+      it "adds object and attacher to collection" do
+        attribute_loader.store(object, "attacher")
+        expect(attribute_loader.send(:serialized_object_attachers)).to eq [[object, "attacher"]]
       end
 
-      it "stores same objects multiple times" do
-        loader.store(object, "attacher1")
-        loader.store(object, "attacher2")
-        expect(loader.send(:objects)).to eq([object, object])
-        expect(loader.send(:serialized_object_attachers)).to eq [
+      it "stores same object multiple times" do
+        attribute_loader.store(object, "attacher1")
+        attribute_loader.store(object, "attacher2")
+        expect(attribute_loader.send(:serialized_object_attachers)).to eq [
           [object, "attacher1"],
           [object, "attacher2"]
         ]
       end
     end
 
-    describe "#load_all" do
-      let(:serializer) { double(__send__: nil) }
-      let(:object1) { double(id: 1) }
-      let(:object2) { double(id: 2) }
+    describe "#load_batch" do
+      it "loads batch values for the given loader via the level" do
+        allow(level).to receive(:load).with(batch_loader).and_return(batch_data)
+
+        expect(attribute_loader.load_batch(batch_loader)).to eq batch_data
+        expect(level).to have_received(:load).with(batch_loader)
+      end
+    end
+
+    describe "#attach" do
+      let(:object1) { double }
+      let(:object2) { double }
       let(:attacher1) { double(call: nil) }
       let(:attacher2) { double(call: nil) }
-      let(:context) { double }
+      let(:batches) { {user: batch_data} }
 
       before do
-        allow(point).to receive(:batch_loaders).and_return([:user])
-        loader.store(object1, attacher1)
-        loader.store(object2, attacher2)
+        attribute_loader.store(object1, attacher1)
+        attribute_loader.store(object2, attacher2)
       end
 
-      it "loads all batch values and attaches them" do
-        allow(serializer).to receive(:__send__)
-        loader.load_all(context)
-        expect(batch_loader).to have_received(:load).with([object1, object2], context)
+      it "calls each attacher with its object and the loaded batches" do
+        attribute_loader.attach(batches)
 
-        expect(attacher1).to have_received(:call).with(object1, {user: batch_data})
-        expect(attacher2).to have_received(:call).with(object2, {user: batch_data})
+        expect(attacher1).to have_received(:call).with(object1, batches)
+        expect(attacher2).to have_received(:call).with(object2, batches)
       end
     end
   end

--- a/spec/serega/batch/attribute_loaders_spec.rb
+++ b/spec/serega/batch/attribute_loaders_spec.rb
@@ -2,59 +2,78 @@
 
 RSpec.describe Serega::SeregaBatch do
   describe Serega::SeregaBatch::AttributeLoaders do
-    subject(:loaders) { described_class.new }
+    subject(:loaders) { described_class.new(context) }
 
-    let(:serializer) { Class.new(Serega) }
+    let(:context) { "CONTEXT" }
     let(:attacher) { "ATTACHER" }
+    let(:serializer) { Class.new(Serega) }
+    let(:plan) { double(:plan) }
     let(:point_class) { class_double(serializer::SeregaPlanPoint, serializer_class: serializer) }
 
+    describe "#add_objects" do
+      it "gathers objects into one level per plan" do
+        loaders.add_objects(plan, [1, 2])
+        loaders.add_objects(plan, [3])
+
+        level = loaders.send(:levels)[plan]
+        expect(level).to be_a(Serega::SeregaBatch::Level)
+        expect(level.objects).to eq [1, 2, 3]
+      end
+
+      it "uses separate levels for different plans" do
+        plan2 = double(:plan2)
+        loaders.add_objects(plan, [1])
+        loaders.add_objects(plan2, [2])
+
+        expect(loaders.send(:levels)[plan].objects).to eq [1]
+        expect(loaders.send(:levels)[plan2].objects).to eq [2]
+      end
+    end
+
     describe "#remember" do
-      let(:point) { instance_double(serializer::SeregaPlanPoint, class: point_class) }
+      let(:point) { instance_double(serializer::SeregaPlanPoint, class: point_class, plan: plan) }
       let(:object) { double }
-      let(:container) { double }
 
-      it "creates new point batch loader for new point" do
+      it "creates new attribute loader for new point" do
         loaders.remember(point, object, attacher)
-        expect(loaders.send(:point_batch_loaders).size).to eq(1)
-        expect(loaders.send(:point_batch_loaders).first).to be_a(Serega::SeregaBatch::AttributeLoader)
+        expect(loaders.send(:attribute_loaders).size).to eq(1)
+        expect(loaders.send(:attribute_loaders).first).to be_a(Serega::SeregaBatch::AttributeLoader)
       end
 
-      it "reuses existing point batch loader for same point" do
+      it "reuses existing attribute loader for same point" do
         loaders.remember(point, object, attacher)
         loaders.remember(point, object, attacher)
-        expect(loaders.send(:point_batch_loaders).size).to eq(1)
+        expect(loaders.send(:attribute_loaders).size).to eq(1)
       end
 
-      it "creates separate point batch loader for different points" do
-        point2 = instance_double(serializer::SeregaPlanPoint, class: point_class)
+      it "creates separate attribute loader for different points" do
+        point2 = instance_double(serializer::SeregaPlanPoint, class: point_class, plan: plan)
         loaders.remember(point, object, attacher)
         loaders.remember(point2, object, attacher)
-        expect(loaders.send(:point_batch_loaders).size).to eq(2)
+        expect(loaders.send(:attribute_loaders).size).to eq(2)
       end
     end
 
     describe "#load_all" do
-      let(:context) { double }
-      let(:point1) { instance_double(serializer::SeregaPlanPoint, class: point_class) }
-      let(:point2) { instance_double(serializer::SeregaPlanPoint, class: point_class) }
+      let(:point1) { instance_double(serializer::SeregaPlanPoint, class: point_class, plan: plan, batch_loaders: [], attribute: double(preloads: nil)) }
+      let(:point2) { instance_double(serializer::SeregaPlanPoint, class: point_class, plan: plan, batch_loaders: [], attribute: double(preloads: nil)) }
       let(:object) { double }
-      let(:container) { double }
 
       before do
         loaders.remember(point1, object, attacher)
         loaders.remember(point2, object, attacher)
       end
 
-      it "loads all point batch loaders" do
-        point_loader1 = loaders.send(:point_batch_loaders).first
-        point_loader2 = loaders.send(:point_batch_loaders).last
-        allow(point_loader1).to receive(:load_all)
-        allow(point_loader2).to receive(:load_all)
+      it "attaches loaded batches to every attribute loader" do
+        attribute_loader1 = loaders.send(:attribute_loaders).first
+        attribute_loader2 = loaders.send(:attribute_loaders).last
+        allow(attribute_loader1).to receive(:attach)
+        allow(attribute_loader2).to receive(:attach)
 
-        loaders.load_all(context)
+        loaders.load_all
 
-        expect(point_loader1).to have_received(:load_all).with(context)
-        expect(point_loader2).to have_received(:load_all).with(context)
+        expect(attribute_loader1).to have_received(:attach).with({})
+        expect(attribute_loader2).to have_received(:attach).with({})
       end
     end
   end

--- a/spec/serega/batch/level_spec.rb
+++ b/spec/serega/batch/level_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Serega::SeregaBatch::Level do
+  subject(:level) { described_class.new(context) }
+
+  let(:context) { "CONTEXT" }
+  let(:batch_loader) { double(load: batch_data) }
+  let(:batch_data) { {1 => "John", 2 => "Jane"} }
+
+  describe "#add_objects" do
+    it "accumulates chunks of objects" do
+      level.add_objects([1, 2])
+      level.add_objects([3])
+      expect(level.objects).to eq [1, 2, 3]
+    end
+  end
+
+  describe "#load" do
+    before { level.add_objects([1, 2]) }
+
+    it "loads values for gathered objects and context" do
+      expect(level.load(batch_loader)).to eq batch_data
+      expect(batch_loader).to have_received(:load).with([1, 2], context)
+    end
+
+    it "loads the same loader only once" do
+      level.load(batch_loader)
+      level.load(batch_loader)
+      expect(batch_loader).to have_received(:load).once
+    end
+
+    it "loads different loaders separately" do
+      other_loader = double(load: {})
+      level.load(batch_loader)
+      level.load(other_loader)
+      expect(batch_loader).to have_received(:load).once
+      expect(other_loader).to have_received(:load).once
+    end
+
+    it "freezes the gathered objects" do
+      level.load(batch_loader)
+      expect(level.objects).to be_frozen
+    end
+
+    it "rejects adding objects once a batch has loaded" do
+      level.load(batch_loader)
+      expect { level.add_objects([3]) }.to raise_error(FrozenError)
+    end
+  end
+end

--- a/spec/serega/plugins/activerecord_preloads/presenter_integration_spec.rb
+++ b/spec/serega/plugins/activerecord_preloads/presenter_integration_spec.rb
@@ -7,19 +7,6 @@ load_plugin_code :activerecord_preloads
 load_plugin_code :presenter
 
 RSpec.describe Serega::SeregaPlugins::ActiverecordPreloads do
-  describe "load order with :presenter" do
-    it "raises when :activerecord_preloads is loaded after :presenter" do
-      serializer = Class.new(Serega) { plugin :presenter }
-      error = "Plugin :activerecord_preloads must be loaded before the :presenter plugin. Please load the :activerecord_preloads plugin first"
-      expect { serializer.plugin(:activerecord_preloads) }.to raise_error Serega::SeregaError, error
-    end
-
-    it "allows :presenter to be loaded after :activerecord_preloads" do
-      serializer = Class.new(Serega) { plugin :activerecord_preloads }
-      expect { serializer.plugin(:presenter) }.not_to raise_error
-    end
-  end
-
   describe "preloading through presenter", :with_rollback do
     let(:user1) { AR::User.create!(first_name: "Bruce", last_name: "Wayne") }
     let(:user2) { AR::User.create!(first_name: "Clark", last_name: "Kent") }

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -815,6 +815,19 @@ RSpec.describe Serega do
         expect(called).to be false
       end
 
+      it "invokes the handler once for an attribute with multiple batch loaders" do
+        calls = []
+        serializer = Class.new(described_class) do
+          preload_with { |objects, preloads| calls << preloads }
+          batch(:a) { |objects| objects.to_h { |object| [object, object] } }
+          batch(:b) { |objects| objects.to_h { |object| [object, object] } }
+          attribute(:value, batch: {use: [:a, :b]}, preload: :assoc) { |obj, batches:| obj }
+        end
+
+        serializer.to_h([1, 2])
+        expect(calls).to eq [:assoc]
+      end
+
       it "raises when an attribute declares :preload but no handler is registered" do
         serializer = Class.new(described_class) do
           attribute :value, preload: :assoc, value: proc { |obj| obj }
@@ -865,6 +878,49 @@ RSpec.describe Serega do
       # block and value together
       expect { serializer_class.batch(:foo, proc {}) {} }
         .to raise_error(Serega::SeregaError, "Batch loader must be defined with a callable value or block")
+    end
+
+    context "when same named batch loader is used by multiple attributes" do
+      subject(:result) { user_serializer.to_h([user1, user2], many: true) }
+
+      let(:load_calls) { [] }
+      let(:user1) { double(id: 1) }
+      let(:user2) { double(id: 2) }
+
+      let(:user_serializer) do
+        calls = load_calls
+        Class.new(Serega) do
+          batch(:stats) do |objects|
+            calls << objects.map(&:id)
+            objects.each_with_object({}) { |obj, hash| hash[obj.id] = {comments: obj.id * 10, likes: obj.id * 100} }
+          end
+
+          attribute(:comments_count, batch: {use: :stats}) { |obj, batches:| batches[:stats][obj.id][:comments] }
+          attribute(:likes_count, batch: {use: :stats}) { |obj, batches:| batches[:stats][obj.id][:likes] }
+        end
+      end
+
+      it "loads the shared batch only once" do
+        expect(result).to eq [
+          {comments_count: 10, likes_count: 100},
+          {comments_count: 20, likes_count: 200}
+        ]
+        expect(load_calls).to eq [[1, 2]]
+      end
+    end
+
+    context "when serialized objects are a non-Array enumerable" do
+      let(:user_serializer) do
+        Class.new(Serega) do
+          batch(:stats) { |users| users.each_with_object({}) { |user, hash| hash[user.id] = user.id * 10 } }
+          attribute(:stat, batch: {use: :stats}) { |user, batches:| batches[:stats][user.id] }
+        end
+      end
+
+      it "batch loads objects gathered from the enumerable" do
+        users = [double(id: 1), double(id: 2)].each # Enumerator, not an Array
+        expect(user_serializer.to_h(users, many: true)).to eq [{stat: 10}, {stat: 20}]
+      end
     end
 
     context "with some error in batch loader" do


### PR DESCRIPTION
Fix batch loading so a named loader reused by several attributes runs once
for the whole set of objects instead of once per attribute.

Introduce SeregaBatch::Level: one per plan level, holding the objects
serialized at that level and a results cache keyed by loader identity. A
named batch loader reused by several attributes at the same level now runs
once for the whole set, and the same loader over a deeper level loads
separately. Objects are gathered once per level (guarded by a memoized
SeregaPlan#batch?) rather than accumulated per attribute.

Levels are keyed by plan identity and results by loader identity (both
compare_by_identity), so nothing relies on the serialized records'

Additional fixes and cleanups:
- hoist preload_associations out of per-loader load_batch so the
  preload_with handler runs once per attribute, not once per named loader
- freeze a level's objects on the first load, sealing the read-only set a
  loader and the preload_with handler receive and turning a stray later
  add_objects into a loud FrozenError