### PR TITLE
Fix :if_value/:unless_value hiding batch attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [Unreleased]
+
+- Fix `:if_value`/`:unless_value` conditions on batch-loaded attributes leaving a
+  `nil` value in the result instead of omitting the key. A batch attribute reserves
+  its slot in the result hash before its value is known; when a value condition then
+  hid the attribute, that reserved key was left behind with a `nil` value. The
+  reserved key is now removed.
+
 ## [0.37.0] - 2026-07-08
 
 - **BREAKING**: `config.hide_by_default` no longer accepts an Array of symbols.

--- a/lib/serega/plugins/if/if.rb
+++ b/lib/serega/plugins/if/if.rb
@@ -275,8 +275,11 @@ class Serega
           super
         end
 
-        def attach_final_value(value, point, _container)
-          return KEY_SKIPPED unless point.satisfy_if_value_conditions?(value, context)
+        def attach_final_value(value, point, container)
+          unless point.satisfy_if_value_conditions?(value, context)
+            container.delete(point.name) # remove reserved placeholder
+            return KEY_SKIPPED
+          end
 
           super
         end

--- a/spec/serega/plugins/if/if_spec.rb
+++ b/spec/serega/plugins/if/if_spec.rb
@@ -254,6 +254,39 @@ RSpec.describe Serega::SeregaPlugins::If do
         end
       end
 
+      context "when skipping batch attribute by :if_value/:unless_value" do
+        let(:user_serializer) do
+          Class.new(Serega) do
+            plugin :if
+
+            attribute :id
+            attribute :online_time,
+              if_value: proc { |val| val != 10 }, # hide when loaded value is 10
+              batch: proc { |_users| {1 => 10, 2 => 20} }
+            attribute :score,
+              unless_value: proc { |val| val == 200 }, # hide when loaded value is 200
+              batch: proc { |_users| {1 => 100, 2 => 200} }
+          end
+        end
+
+        let(:users) do
+          [
+            double(id: 1),
+            double(id: 2)
+          ]
+        end
+
+        it "removes the reserved placeholder key instead of leaving a nil value" do
+          result = user_serializer.to_h(users)
+          expect(result).to eq(
+            [
+              {id: 1, score: 100}, # online_time hidden by :if_value
+              {id: 2, online_time: 20} # score hidden by :unless_value
+            ]
+          )
+        end
+      end
+
       context "when skipping relation attribute and nested attributes" do
         let(:status_serializer) do
           _status1, _status2, status3, status4, _status5 = statuses


### PR DESCRIPTION
Batch attributes reserve their slot in the result hash with a nil placeholder before the loaded value is known, then backfill it after the batch loads. When an :if_value/:unless_value condition hid such an attribute, `attach_final_value` returned early without setting a value but left the reserved key behind, so the attribute appeared in the output with a nil value instead of being omitted.

Delete the reserved key when a value condition hides the attribute (a no-op for inline attributes, which never reserve a placeholder).