### PR TITLE
Make auto-batch a no-op marker; clarify the :auto-hide rule

### DIFF
--- a/lib/serega/attribute_normalizer.rb
+++ b/lib/serega/attribute_normalizer.rb
@@ -9,10 +9,6 @@ class Serega
     # AttributeNormalizer instance methods
     #
     module AttributeNormalizerInstanceMethods
-      # Identity loader that routes relation/preload attributes through the batch
-      # mechanism. Its result is never read — the attribute's value block still
-      # computes the value.
-      AUTO_BATCH_LOADER = proc { |records| records.to_h { |record| [record, record] } }
       # Attribute initial params
       # @return [Hash] Attribute initial params
       attr_reader :init_name, :init_opts, :init_block
@@ -152,11 +148,22 @@ class Serega
 
         hide_setting = config.hide_by_default
         return true if hide_setting == true
-        return true if hide_setting == :auto && (preloads || init_opts.key?(:batch))
+        return true if hide_setting == :auto && preload_or_batch?
 
         # Return nil for undefined value which means "not hide" but allows
         # to change this value by plugins
         nil
+      end
+
+      # The `hide_by_default = :auto` criterion: hide attributes that fetch extra
+      # data on demand — those declared with `:preload` or an explicit `:batch`.
+      #
+      # This is intentionally narrower than a "goes through the batch mechanism"
+      # check (`SeregaPlanPoint#batch?`): a plain relation (`serializer:` without
+      # `:preload`) is batch-processed too, but it only serializes an already-loaded
+      # nested object, so it stays visible by default.
+      def preload_or_batch?
+        !!(preloads || init_opts.key?(:batch))
       end
 
       def config
@@ -197,9 +204,11 @@ class Serega
         return explicit_batch_loaders(batch_opt) if batch_opt
         return FROZEN_EMPTY_ARRAY unless serializer || preloads
 
-        loader_name = :"__auto_batch_#{name}__"
-        self.class.serializer_class.batch(loader_name, AUTO_BATCH_LOADER)
-        [loader_name]
+        # Relations and preloads only need to be routed through the batch phase
+        # (so objects are gathered per level and preloads run) — there is nothing
+        # to load, since the value comes from the attribute's own resolver. Mark
+        # them with the reserved marker; the batch machinery skips it.
+        [SeregaBatch::AUTO_BATCH_LOADER_NAME]
       end
 
       def explicit_batch_loaders(batch_opt)

--- a/lib/serega/batch/attribute_loaders.rb
+++ b/lib/serega/batch/attribute_loaders.rb
@@ -5,6 +5,11 @@ class Serega
   # Batch feature main module
   #
   module SeregaBatch
+    # Reserved batch-loader name that marks relation/preload attributes as
+    # batch-processed. It has no registered loader — the attribute's value comes
+    # from its own resolver — so `load_batches` skips it (nothing to load).
+    AUTO_BATCH_LOADER_NAME = :__auto_batch__
+
     #
     # Batch loaders
     #
@@ -98,6 +103,10 @@ class Serega
 
         batches = {}
         point.batch_loaders.each do |batch_loader_name|
+          # Auto-batched relations/preloads carry the marker, not a real loader:
+          # their value comes from their own resolver, so there is nothing to load.
+          next if batch_loader_name == AUTO_BATCH_LOADER_NAME
+
           loader = serializer_class.batch_loaders[batch_loader_name]
           batches[batch_loader_name] = attribute_loader.load_batch(loader)
         end

--- a/spec/serega/attribute_normalizer_spec.rb
+++ b/spec/serega/attribute_normalizer_spec.rb
@@ -248,6 +248,24 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
       expect(serializer.attributes[:likes].batch_loaders).not_to be_empty
     end
 
+    it "marks auto-batched attributes with a shared marker and registers no loader" do
+      child = Class.new(Serega)
+      serializer = Class.new(Serega) do
+        attribute :author, serializer: child
+        attribute :editor, serializer: child
+        attribute :likes, preload: :likes, value: proc { |o| o }
+      end
+
+      # No synthetic loaders are registered — the marker has nothing to load
+      expect(serializer.batch_loaders).to be_empty
+
+      # every auto-batched attribute carries the same reserved marker
+      marker = [Serega::SeregaBatch::AUTO_BATCH_LOADER_NAME]
+      expect(serializer.attributes[:author].batch_loaders).to eq marker
+      expect(serializer.attributes[:editor].batch_loaders).to eq marker
+      expect(serializer.attributes[:likes].batch_loaders).to eq marker
+    end
+
     describe "hide_by_default :auto" do
       it "keeps a plain serializer relation visible" do
         child = Class.new(Serega)


### PR DESCRIPTION
Relations and preloads are routed through the batch phase only so their
objects are gathered per level and preloads run — the value itself comes
from the attribute's own resolver. Previously each such attribute
registered a distinct `__auto_batch_<name>__` identity loader that built a
`{obj => obj}` hash which was never read.

Replace that with a reserved marker name (SeregaBatch::AUTO_BATCH_LOADER_NAME)
that has no registered loader: `load_batches` skips it, so nothing is
registered and no identity hash is ever built. This removes the per-
attribute batch_loaders growth, the registration side effect, and the
wasted per-level load.

Also extract the `hide_by_default = :auto` rule into a documented
`preload_or_batch?` predicate. It reads like it should match
`SeregaPlanPoint#batch?` but deliberately does not — a plain relation is
batch-processed yet stays visible — so the named predicate makes the
intended, narrower criterion explicit.

No behavior change; existing hide/serialization specs pass, plus a test
asserting auto-batched attributes register no loader.