### PR TITLE
Serialize Struct and Hash as single objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## [Unreleased]
+
+- Fix Struct objects being serialized as collections. Structs are Enumerable,
+  so the automatic `:many` detection treated them as multiple objects and
+  serialized each member value separately. Now a Struct is serialized as a
+  single object and the `many: false` workaround is not needed anymore.
+
+- Fix Hash objects being serialized as collections of key-value pairs by
+  the automatic `:many` detection. Now a Hash is serialized as a single
+  object (define attribute values with the `value: <callable>` option, as
+  hashes usually have no reader methods).
+
 ## [0.38.0] - 2026-07-09
 
 - Rework the core serialization engine. Serialization now runs **level by

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -142,12 +142,6 @@ UserSerializer.to_data(user) # Ruby Data object (3.2+) => #<data name="Felonious
 UserSerializer.new(only: [:name]).to_h(user) # reuse — serialization plan built once
 ```
 
-```ruby
-# Struct is Enumerable — force single (see [§6 Relations][relations] for `many:`)
-quote = Struct.new(:text).new('I am going to steal the moon')
-QuoteSerializer.to_h(quote, many: false)
-```
-
 ---
 
 ## 4. Field Selection — `:only` `:except` `:with`

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ class UserSerializer < Serega
 
   # Option `:many` specifies a has_many relationship. It is optional.
   # If not specified, it is defined during serialization by checking
-  # `object.is_a?(Enumerable)`
+  # `object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)`
   # Also the `:many` changes the default value from `nil` to `[]`.
   attribute :posts, serializer: PostSerializer, many: true
 
@@ -181,15 +181,6 @@ serializer.to_h(user2)
 serializer = UserSerializer.new(only: [:username, :avatar])
 serializer.to_h(user1)
 serializer.to_h(user2)
-```
-
----
-⚠️ When you serialize the `Struct` object, specify manually `many: false`. As Struct
-is Enumerable and we check `object.is_a?(Enumerable)` to detect if we should
-return array.
-
-```ruby
-UserSerializer.to_h(user_struct, many: false)
 ```
 
 ### Selecting Fields

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -19,6 +19,7 @@ end
 
 require_relative "serega/errors"
 require_relative "serega/helpers/serializer_class_helper"
+require_relative "serega/utils/collection_detector"
 require_relative "serega/utils/enum_deep_dup"
 require_relative "serega/utils/enum_deep_freeze"
 require_relative "serega/utils/method_signature"
@@ -254,7 +255,7 @@ class Serega
     # @option opts [Array, Hash, String, Symbol] :with Attributes (usually hidden) to serialize additionally
     # @option opts [Boolean] :validate Validates provided modifiers (Default is true)
     # @option opts [Hash] :context Serialization context
-    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable)`)
+    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)`)
     #
     # @return [Hash] Serialization result
     #
@@ -275,7 +276,7 @@ class Serega
     # @option opts [Array, Hash, String, Symbol] :with Attributes (usually hidden) to serialize additionally
     # @option opts [Boolean] :validate Validates provided modifiers (Default is true)
     # @option opts [Hash] :context Serialization context
-    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable)`)
+    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)`)
     #
     # @return [Data, Array<Data>, nil] Serialization result as Data object(s)
     #
@@ -409,7 +410,7 @@ class Serega
     # @param object [Object] Serialized object
     # @param opts [Hash, nil] Serializing options
     # @option opts [Hash] :context Serialization context
-    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable)`)
+    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)`)
     #
     # @return [Hash] Serialization result
     #
@@ -431,7 +432,7 @@ class Serega
     # @param object [Object] Serialized object
     # @param opts [Hash, nil] Serializing options
     # @option opts [Hash] :context Serialization context
-    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable)`)
+    # @option opts [Boolean] :many Set true if provided multiple objects (Default `object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)`)
     #
     # @return [Data] Serialization result
     #
@@ -472,7 +473,7 @@ class Serega
 
       opts[:context] ||= {}
       opts[:level_queue] = SeregaEngine::LevelQueue.new
-      opts[:many] = object.is_a?(Enumerable) unless opts.key?(:many)
+      opts[:many] = SeregaUtils::CollectionDetector.call(object) unless opts.key?(:many)
       opts[:plan] = plan
       opts
     end

--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -45,7 +45,7 @@ class Serega
       # @option opts [Symbol] :method Object method name to fetch attribute value
       # @option opts [Hash] :delegate Allows to fetch value from nested object
       # @option opts [Boolean] :hide Specify `true` to not serialize this attribute by default
-      # @option opts [Boolean] :many Specifies has_many relationship. By default is detected via object.is_a?(Enumerable)
+      # @option opts [Boolean] :many Specifies has_many relationship. By default is detected via object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)
       # @option opts [Proc, #call] :value Custom block or callable to find attribute value
       # @option opts [Serega, Proc] :serializer Relationship serializer class. Use `proc { MySerializer }` if serializers have cross references
       # @param block [Proc] Custom block to find attribute value

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -97,14 +97,14 @@ class Serega
       end
 
       # How to serialize `object`, deciding whether the result is a collection or a
-      # single object and reading `Enumerable` only once:
+      # single object and checking the object type only once:
       # - :many         — `many` is on and the object is a collection
       # - :many_for_one — `many` is on but a sole object was given (wrap it, don't raise)
       # - :one          — serialize the object on its own
       def serialize_mode(object)
         case many
-        when NilClass then object.is_a?(Enumerable) ? :many : :one
-        when TrueClass then object.is_a?(Enumerable) ? :many : :many_for_one
+        when NilClass then SeregaUtils::CollectionDetector.call(object) ? :many : :one
+        when TrueClass then SeregaUtils::CollectionDetector.call(object) ? :many : :many_for_one
         else :one # many == false
         end
       end

--- a/lib/serega/plugins/root/root.rb
+++ b/lib/serega/plugins/root/root.rb
@@ -244,7 +244,7 @@ class Serega
           return opts[:root] if opts.key?(:root)
 
           root = self.class.config.root
-          (opts.fetch(:many) { object.is_a?(Enumerable) }) ? root.many : root.one
+          (opts.fetch(:many) { SeregaUtils::CollectionDetector.call(object) }) ? root.many : root.one
         end
       end
 

--- a/lib/serega/utils/collection_detector.rb
+++ b/lib/serega/utils/collection_detector.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Serega
+  module SeregaUtils
+    #
+    # Utility to check if an object should be serialized as a collection.
+    #
+    # Hashes and Structs are Enumerable, but enumerate their own member
+    # values, so they are treated as single objects.
+    #
+    class CollectionDetector
+      class << self
+        #
+        # Checks if provided object is a collection of objects
+        #
+        # @param object [Object] Serialized object
+        #
+        # @return [Boolean] whether object should be serialized as a collection
+        #
+        def call(object)
+          object.is_a?(Enumerable) && !object.is_a?(Hash) && !object.is_a?(Struct)
+        end
+      end
+    end
+  end
+end

--- a/spec/serega/plugins/presenter/presenter_spec.rb
+++ b/spec/serega/plugins/presenter/presenter_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
       attribute :nested, serializer: current_serializer
     end
 
-    result = base_serializer.new.to_h(struct, many: false)
+    result = base_serializer.new.to_h(struct)
     expect(result).to eq({nested: {rev: "321"}})
   end
 end

--- a/spec/serega/utils/collection_detector_spec.rb
+++ b/spec/serega/utils/collection_detector_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Serega::SeregaUtils::CollectionDetector do
+  it "returns true for Enumerable objects" do
+    expect(described_class.call([])).to be true
+    expect(described_class.call(Set.new)).to be true
+    expect(described_class.call([].each)).to be true
+  end
+
+  it "returns false for non-Enumerable objects" do
+    expect(described_class.call(nil)).to be false
+    expect(described_class.call("string")).to be false
+    expect(described_class.call(Object.new)).to be false
+  end
+
+  it "returns false for Hash objects" do
+    expect(described_class.call({})).to be false
+  end
+
+  it "returns false for Struct objects" do
+    point_struct = Struct.new(:x, :y)
+    expect(described_class.call(point_struct.new(1, 2))).to be false
+  end
+end

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -448,6 +448,56 @@ RSpec.describe Serega do
       end
     end
 
+    context "with Struct object" do
+      let(:user_struct) { Struct.new(:first_name, :last_name) }
+      let(:user) { user_struct.new("FIRST_NAME", "LAST_NAME") }
+
+      it "serializes Struct as a single object, not as a collection" do
+        expect(result).to eq({first_name: "FIRST_NAME", last_name: "LAST_NAME"})
+      end
+
+      it "wraps Struct in an array when :many option is true" do
+        expect(user_serializer.to_h(user, many: true))
+          .to eq([{first_name: "FIRST_NAME", last_name: "LAST_NAME"}])
+      end
+    end
+
+    context "with Hash object" do
+      let(:user_serializer) do
+        Class.new(Serega) do
+          attribute :first_name, value: proc { |user| user[:first_name] }
+          attribute :last_name, value: proc { |user| user[:last_name] }
+        end
+      end
+      let(:user) { {first_name: "FIRST_NAME", last_name: "LAST_NAME"} }
+
+      it "serializes Hash as a single object, not as a collection of key-value pairs" do
+        expect(result).to eq({first_name: "FIRST_NAME", last_name: "LAST_NAME"})
+      end
+    end
+
+    context "with object with Struct relation" do
+      let(:statistics_struct) { Struct.new(:likes_count, :comments_count) }
+      let(:statistics_serializer) do
+        Class.new(Serega) do
+          attribute :likes_count
+          attribute :comments_count
+        end
+      end
+
+      let(:user) { double(statistics: statistics_struct.new(10, 20)) }
+      let(:user_serializer) do
+        child_serializer = statistics_serializer
+        Class.new(Serega) do
+          attribute :statistics, serializer: child_serializer
+        end
+      end
+
+      it "serializes Struct relation as a single object, not as a collection" do
+        expect(result).to eq({statistics: {likes_count: 10, comments_count: 20}})
+      end
+    end
+
     context "with object with relation" do
       let(:comment) { double(text: "TEXT") }
       let(:comment_serializer) do


### PR DESCRIPTION
Structs and Hashes are Enumerable, so the automatic :many detection treated them as collections: a Struct was exploded into its member values and a Hash into [key, value] pairs, both failing with misleading errors.

Add SeregaUtils::CollectionDetector util holding the detection logic (Enumerable, except Hash and Struct) and use it in all three auto-detection sites: initial serialization opts,
SeregaObjectSerializer#serialize_mode and the root plugin build_root fallback.

Remove the "specify many: false for Structs" workaround notes from README and CHEATSHEET and the workaround itself from presenter specs.