### PR TITLE
Add config.auto_preload_excluded_methods option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- New `config.auto_preload_excluded_methods` option (default `[:itself]`) —
+  methods that are never auto-preloaded, as they return the serialized object
+  itself and not an association. Applies to the `:method` option of attributes
+  with a serializer and to the `delegate: {to: ...}` option. The `:presenter`
+  plugin appends its `:__getobj__` unwrap method to the list when loaded.
+  Previously `method: :itself` with `auto_preload` enabled generated a bogus
+  `:itself` preload (and made `hide_by_default = :auto` hide the attribute).
+
 - Fix Struct objects being serialized as collections. Structs are Enumerable,
   so the automatic `:many` detection treated them as multiple objects and
   serialized each member value separately. Now a Struct is serialized as a

--- a/lib/serega/attribute_normalizer.rb
+++ b/lib/serega/attribute_normalizer.rb
@@ -250,15 +250,24 @@ class Serega
 
         # Auto-preload the delegated association
         if config.auto_preload.fetch(:has_delegate_option) && init_opts[:delegate]
-          return init_opts[:delegate][:to]
+          return auto_preload_value(init_opts[:delegate][:to])
         end
 
         # Auto-preload the nested serializer's association
         if config.auto_preload.fetch(:has_serializer_option) && init_opts[:serializer] && !init_opts.key?(:batch)
-          return method_name
+          return auto_preload_value(method_name)
         end
 
         nil
+      end
+
+      # Skips auto-preloading of methods that return the serialized object
+      # itself (:itself by default) — they are not associations,
+      # so preloading them would fail or make no sense.
+      def auto_preload_value(preload_method)
+        return nil if config.auto_preload_excluded_methods.include?(preload_method.to_sym)
+
+        preload_method
       end
     end
 

--- a/lib/serega/config.rb
+++ b/lib/serega/config.rb
@@ -31,6 +31,7 @@ class Serega
       delegate_default_allow_nil: false,
       max_cached_plans_per_serializer_count: 0,
       auto_preload: {has_delegate_option: false, has_serializer_option: false},
+      auto_preload_excluded_methods: %i[itself].freeze,
       hide_by_default: false,
       batch_id_option: :id
     }.freeze
@@ -112,6 +113,29 @@ class Serega
       def delegate_default_allow_nil=(value)
         raise SeregaError, "Must have boolean value, #{value.inspect} provided" if (value != true) && (value != false)
         opts[:delegate_default_allow_nil] = value
+      end
+
+      # Returns :auto_preload_excluded_methods config option — methods that are
+      # never auto-preloaded, as they return the serialized object itself and
+      # not an association
+      # @return [Array<Symbol>] Current :auto_preload_excluded_methods config option
+      def auto_preload_excluded_methods
+        opts.fetch(:auto_preload_excluded_methods)
+      end
+
+      # Sets :auto_preload_excluded_methods config option — methods that are
+      # never auto-preloaded. Applies to the `:method` option of attributes
+      # with a serializer and to the `delegate: {to: ...}` option.
+      #
+      # @param value [Array<Symbol>] Method names to skip in auto-preload
+      #
+      # @return [Array<Symbol>] New :auto_preload_excluded_methods config option
+      def auto_preload_excluded_methods=(value)
+        unless value.is_a?(Array) && value.all?(Symbol)
+          raise SeregaError, "Must be an Array of Symbols, #{value.inspect} provided"
+        end
+
+        opts[:auto_preload_excluded_methods] = value
       end
 
       # Returns :hide_by_default config option

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -62,6 +62,11 @@ class Serega
         presenter_class = Class.new(Presenter)
         presenter_class.serializer_class = serializer_class
         serializer_class.const_set(:Presenter, presenter_class)
+
+        # The presenter's unwrap method returns the serialized object itself,
+        # not an association — it must never be auto-preloaded.
+        config = serializer_class.config
+        config.auto_preload_excluded_methods = config.auto_preload_excluded_methods | [:__getobj__]
       end
 
       # Presenter class

--- a/spec/serega/attribute_normalizer_spec.rb
+++ b/spec/serega/attribute_normalizer_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
       it "hides attribute with empty :batch use list (batch key present)" do
         expect(normalizer.new(name: :foo, opts: {batch: {use: []}}).hide).to be(true)
       end
+
+      it "does not hide attribute when auto preload resolves to an excluded method" do
+        serializer_class.config.auto_preload = true
+        norm = normalizer.new(name: :statistics, opts: {serializer: "bar", method: :itself})
+        expect(norm.hide).to be_nil
+      end
     end
 
     context "with hide_by_default: true" do
@@ -341,6 +347,39 @@ RSpec.describe Serega::SeregaAttributeNormalizer do
 
       it "returns no preloads for attributes with :delegate option by default" do
         opts[:delegate] = {to: :bar}
+        expect(norm.preloads).to be_nil
+      end
+
+      it "skips auto preloads for excluded methods of attributes with serializer" do
+        serializer_class.config.auto_preload = {has_serializer_option: true}
+        opts[:serializer] = "bar"
+        opts[:method] = :itself
+        expect(norm.preloads).to be_nil
+      end
+
+      it "skips auto preloads for excluded methods of attributes with :delegate option" do
+        serializer_class.config.auto_preload = {has_delegate_option: true}
+        opts[:delegate] = {to: :itself}
+        expect(norm.preloads).to be_nil
+      end
+
+      it "skips auto preloads for custom auto_preload_excluded_methods" do
+        serializer_class.config.auto_preload = {has_serializer_option: true}
+        serializer_class.config.auto_preload_excluded_methods = %i[current_object]
+        opts[:serializer] = "bar"
+        opts[:method] = :current_object
+        expect(norm.preloads).to be_nil
+      end
+
+      it "skips auto preloads for excluded methods provided as String" do
+        serializer_class.config.auto_preload = true
+        opts[:delegate] = {to: "itself"}
+        expect(norm.preloads).to be_nil
+      end
+
+      it "returns no auto preloads for attributes with only :method option" do
+        serializer_class.config.auto_preload = true
+        opts[:method] = :profile
         expect(norm.preloads).to be_nil
       end
     end

--- a/spec/serega/config_spec.rb
+++ b/spec/serega/config_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe Serega::SeregaConfig do
     end
   end
 
+  describe "#auto_preload_excluded_methods" do
+    it "returns default value" do
+      expect(config.auto_preload_excluded_methods).to eq %i[itself]
+    end
+  end
+
+  describe "#auto_preload_excluded_methods=" do
+    it "validates value is an Array of Symbols" do
+      expect { config.auto_preload_excluded_methods = [] }.not_to raise_error
+      expect { config.auto_preload_excluded_methods = %i[itself current_object] }.not_to raise_error
+      expect { config.auto_preload_excluded_methods = :itself }
+        .to raise_error Serega::SeregaError, "Must be an Array of Symbols, :itself provided"
+      expect { config.auto_preload_excluded_methods = ["itself"] }
+        .to raise_error Serega::SeregaError, "Must be an Array of Symbols, [\"itself\"] provided"
+    end
+
+    it "sets auto_preload_excluded_methods option" do
+      config.auto_preload_excluded_methods = %i[current_object]
+      expect(config.auto_preload_excluded_methods).to eq %i[current_object]
+    end
+  end
+
   describe "#hide_by_default=" do
     it "validates value" do
       expect { config.hide_by_default = false }.not_to raise_error

--- a/spec/serega/plugins/presenter/presenter_spec.rb
+++ b/spec/serega/plugins/presenter/presenter_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
     it "adds serializer::Presenter class" do
       expect(serializer::Presenter).to be_a Class
     end
+
+    it "appends :__getobj__ to auto_preload_excluded_methods" do
+      expect(serializer.config.auto_preload_excluded_methods).to eq %i[itself __getobj__]
+    end
+
+    it "preserves customized auto_preload_excluded_methods when appending :__getobj__" do
+      custom_serializer = Class.new(Serega) do
+        config.auto_preload_excluded_methods = %i[current_object]
+        plugin :presenter
+      end
+
+      expect(custom_serializer.config.auto_preload_excluded_methods).to eq %i[current_object __getobj__]
+    end
   end
 
   describe ".inherited" do
@@ -107,5 +120,14 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
 
     result = base_serializer.new.to_h(struct)
     expect(result).to eq({nested: {rev: "321"}})
+  end
+
+  it "does not auto-preload the :__getobj__ unwrap method" do
+    nested_serializer = Class.new(Serega) { attribute :id }
+    serializer.config.auto_preload = true
+    attribute = serializer.attribute :statistics, serializer: nested_serializer, method: :__getobj__
+
+    expect(attribute.preloads).to be_nil
+    expect(serializer.to_h(double(id: 1))).to eq(statistics: {id: 1})
   end
 end

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Serega do
         delegate_default_allow_nil
         max_cached_plans_per_serializer_count
         auto_preload
+        auto_preload_excluded_methods
         hide_by_default
         batch_id_option
       ]
@@ -48,6 +49,7 @@ RSpec.describe Serega do
       expect(config.max_cached_plans_per_serializer_count).to eq 0
       expect(config.hide_by_default).to be false
       expect(config.auto_preload).to eq(has_delegate_option: false, has_serializer_option: false)
+      expect(config.auto_preload_excluded_methods).to eq %i[itself]
       expect(config.batch_id_option).to eq :id
     end
   end


### PR DESCRIPTION
Methods listed in this option (default [:itself, :__getobj__]) are never auto-preloaded, as they return the serialized object itself and not an association. Applies to the :method option of attributes with a serializer and to the delegate: {to:} option.

Previously method: :itself with auto_preload enabled generated a bogus :itself preload (and made hide_by_default = :auto hide the attribute).