### PR TITLE
Skip Presenter wrapping when Presenter class has no custom methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+- Plugin `:presenter` no longer wraps serialized objects in the Presenter
+  class when it (and its inherited Presenter classes) has no custom methods —
+  a bare `plugin :presenter` in a base serializer now adds no per-object
+  overhead. Wrapping turns on automatically as soon as any method is defined
+  on (or any module is included into / prepended to) the Presenter class, even
+  after serialization already happened. New `SerializerClass.custom_presenter?`
+  method tells whether objects will be wrapped. Note for batch loaders and
+  value callables: they receive presenter-wrapped objects only when the
+  presenter is customized; with an untouched Presenter they now receive the
+  raw objects (so `object.is_a?`/`object.class` checks work again).
+
 - New `config.auto_preload_excluded_methods` option (default `[:itself]`) —
   methods that are never auto-preloaded, as they return the serialized object
   itself and not an association. Applies to the `:method` option of attributes

--- a/README.md
+++ b/README.md
@@ -816,6 +816,12 @@ The original wrapped object is accessible via `__getobj__` (standard
 
 The serialization context is accessible via the private method `__ctx__`.
 
+Objects are wrapped in the `Presenter` only when the serializer's `Presenter`
+class (or an inherited one) actually defines custom methods. Loading the
+plugin in a base serializer adds no overhead to serializers that don't
+customize their presenters — their attribute values, batch loaders and value
+callables keep receiving the raw objects.
+
 ### Plugin :string_modifiers
 
 Allows to specify modifiers as strings.

--- a/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
+++ b/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
@@ -91,6 +91,7 @@ class Serega
       # The underlying records to preload onto. The :presenter plugin wraps every
       # serialized object in a SimpleDelegator, but ActiveRecord's Preloader needs
       # the real records, so unwrap them via #__getobj__ when presenter is used.
+      # Objects are wrapped only when the Presenter class has custom methods.
       #
       # @param serializer_class [Class<Serega>] Current serializer class
       # @param objects [Array] objects serialized at the current level
@@ -99,6 +100,7 @@ class Serega
       #
       def self.records(serializer_class, objects)
         return objects unless serializer_class.plugin_used?(:presenter)
+        return objects unless serializer_class.custom_presenter?
 
         objects.map(&:__getobj__)
       end

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -15,6 +15,12 @@ class Serega
     # - The original object is accessible via __getobj__ (standard SimpleDelegator API).
     # - The serialization context is accessible via the private method __ctx__.
     #
+    # Objects are wrapped in the Presenter only when the serializer's Presenter
+    # class (or an inherited one) was actually extended with custom methods —
+    # a bare `plugin :presenter` adds no wrapping overhead. The check is
+    # denormalized: `SerializerClass.custom_presenter?` is asked once per
+    # object serializer and the result is reused for the whole level.
+    #
     #   class UserSerializer < Serega
     #     plugin :presenter
     #
@@ -102,6 +108,44 @@ class Serega
         extend SeregaHelpers::SerializerClassHelper
         extend Forwardable
         include InstanceMethods
+
+        # Tracks whether user code was added to the Presenter class.
+        #
+        # These singleton methods are defined after the base class body above,
+        # so the plugin's own includes do not mark the base class as modified.
+        # Lazy delegators defined by #method_missing do mark the class, but
+        # they can appear only on presenters that are already wrapping.
+        class << self
+          #
+          # Checks if this Presenter class (or an inherited one) was extended
+          # with custom user code and therefore objects must be wrapped
+          #
+          # @return [Boolean] whether custom presenter methods were defined
+          #
+          def modified?
+            return true if defined?(@modified)
+            return false if equal?(Presenter) # the plugin's base class — the walk stops here
+
+            superclass.modified?
+          end
+
+          def include(*modules)
+            @modified = true
+            super
+          end
+
+          def prepend(*modules)
+            @modified = true
+            super
+          end
+
+          private
+
+          def method_added(name)
+            @modified = true
+            super
+          end
+        end
       end
 
       #
@@ -110,6 +154,17 @@ class Serega
       # @see Serega
       #
       module ClassMethods
+        #
+        # Checks if the serializer's Presenter class (or an inherited one) was
+        # extended with custom user code. When it was not, serialized objects
+        # are not wrapped in the Presenter at all.
+        #
+        # @return [Boolean] whether custom presenter methods were defined
+        #
+        def custom_presenter?
+          self::Presenter.modified?
+        end
+
         private
 
         def inherited(subclass)
@@ -127,14 +182,25 @@ class Serega
       # @see Serega::SeregaObjectSerializer
       #
       module SeregaObjectSerializerInstanceMethods
+        # The custom-presenter check is made once per object serializer here
+        # and its result is reused for every enqueued chunk of the level.
+        def initialize(**opts)
+          super
+          @wrap_in_presenter = self.class.serializer_class.custom_presenter?
+        end
+
         private
 
         #
         # Wraps each serialized object in Presenter.new(object, ctx) before it is
         # enqueued, so the whole level — value resolution and batch loaders alike —
-        # sees presenters.
+        # sees presenters. Objects are not wrapped when the Presenter class has
+        # no custom methods — such wrapping would only add overhead and break
+        # class checks (object.is_a?, Hash === object) without changing anything.
         #
         def enqueue(objects)
+          return super unless @wrap_in_presenter
+
           presenter = self.class.serializer_class::Presenter
           presenters = objects.map { |object| presenter.new(object, context) }
           super(presenters)

--- a/spec/serega/plugins/activerecord_preloads/activerecord_preloads_spec.rb
+++ b/spec/serega/plugins/activerecord_preloads/activerecord_preloads_spec.rb
@@ -28,9 +28,21 @@ RSpec.describe Serega::SeregaPlugins::ActiverecordPreloads do
       expect(described_class.records(serializer, objects)).to equal objects
     end
 
-    it "unwraps presenter-wrapped objects to their underlying records when :presenter is used" do
+    it "returns objects unchanged when the Presenter class has no custom methods" do
       serializer.plugin(:activerecord_preloads)
       serializer.plugin(:presenter)
+
+      objects = [Object.new, Object.new]
+      expect(described_class.records(serializer, objects)).to equal objects
+    end
+
+    it "unwraps presenter-wrapped objects to their underlying records when custom presenter is used" do
+      serializer.plugin(:activerecord_preloads)
+      serializer.plugin(:presenter)
+      serializer::Presenter.class_exec do
+        def name
+        end
+      end
       record1, record2 = Object.new, Object.new
 
       objects = [SimpleDelegator.new(record1), SimpleDelegator.new(record2)]

--- a/spec/serega/plugins/presenter/presenter_spec.rb
+++ b/spec/serega/plugins/presenter/presenter_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
   end
 
   it "adds presenter methods used in block after first serialization" do
+    serializer::Presenter.class_exec do
+      def rev
+      end
+    end
     serializer.attribute(:length) { |obj| obj.size }
 
     expect(serializer::Presenter.instance_methods).not_to include(:size)
@@ -123,11 +127,110 @@ RSpec.describe Serega::SeregaPlugins::Presenter do
   end
 
   it "does not auto-preload the :__getobj__ unwrap method" do
+    # objects are wrapped (and __getobj__ is meaningful) only when the
+    # Presenter is customized
+    serializer::Presenter.class_exec do
+      def rating
+      end
+    end
+
     nested_serializer = Class.new(Serega) { attribute :id }
     serializer.config.auto_preload = true
     attribute = serializer.attribute :statistics, serializer: nested_serializer, method: :__getobj__
 
     expect(attribute.preloads).to be_nil
     expect(serializer.to_h(double(id: 1))).to eq(statistics: {id: 1})
+  end
+
+  describe "skipping wrapping when Presenter has no custom methods" do
+    it "does not wrap objects in Presenter" do
+      received = nil
+      serializer.attribute(:name) { |obj|
+        received = obj
+        obj.to_s
+      }
+
+      serializer.new.to_h("raw object")
+
+      expect(received).to eq "raw object"
+      expect(received).not_to be_a(SimpleDelegator)
+    end
+
+    it "wraps objects when Presenter is reopened after first serialization" do
+      received = nil
+      serializer.attribute(:name) { |obj|
+        received = obj
+        obj.to_s
+      }
+
+      serializer.new.to_h("raw object")
+      expect(received).not_to be_a(SimpleDelegator)
+
+      serializer::Presenter.class_exec do
+        def to_s
+          "presented"
+        end
+      end
+
+      result = serializer.new.to_h("raw object")
+      expect(received).to be_a(SimpleDelegator)
+      expect(result).to eq({name: "presented"})
+    end
+  end
+
+  describe ".custom_presenter?" do
+    it "returns false when Presenter was not modified" do
+      expect(serializer.custom_presenter?).to be false
+    end
+
+    it "returns true when a method was defined on Presenter" do
+      serializer::Presenter.class_exec do
+        def name
+        end
+      end
+
+      expect(serializer.custom_presenter?).to be true
+    end
+
+    it "returns true when a module was included into Presenter" do
+      presenter_methods = Module.new do
+        def name
+        end
+      end
+      serializer::Presenter.include(presenter_methods)
+
+      expect(serializer.custom_presenter?).to be true
+    end
+
+    it "returns true when a module was prepended to Presenter" do
+      presenter_methods = Module.new do
+        def name
+        end
+      end
+      serializer::Presenter.prepend(presenter_methods)
+
+      expect(serializer.custom_presenter?).to be true
+    end
+
+    it "returns true for a child of a serializer with modified Presenter" do
+      serializer::Presenter.class_exec do
+        def name
+        end
+      end
+
+      child = Class.new(serializer)
+      expect(child.custom_presenter?).to be true
+    end
+
+    it "stays false on the parent when only the child Presenter is modified" do
+      child = Class.new(serializer)
+      child::Presenter.class_exec do
+        def name
+        end
+      end
+
+      expect(child.custom_presenter?).to be true
+      expect(serializer.custom_presenter?).to be false
+    end
   end
 end


### PR DESCRIPTION
Loading plugin :presenter in a base serializer previously wrapped every serialized object in a SimpleDelegator even when no presenter methods were ever defined — pure overhead that also broke class checks (object.is_a?, Hash === object) in value callables and batch loaders.

Track user modifications of per-serializer Presenter classes with method_added/include/prepend hooks installed after the plugin's own base class body. Presenter.modified? walks the inheritance chain, so a child serializer keeps wrapping when a parent Presenter is customized. The check is denormalized: SerializerClass.custom_presenter? is asked once per object serializer and reused for the whole level, while the live definition-time flag means reopening a Presenter after the first serialization enables wrapping on the next one — no stale caching.

The activerecord_preloads plugin unwraps objects via #__getobj__ only when the presenter is actually customized.