### PR TITLE
Fix and document `batch: <loader_name>` short form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+- Fix `batch: <loader_name>` short form (Symbol or String) raising a TypeError
+  when the attribute had no explicit `:value` option — the default batch value
+  resolution now supports it:
+
+  ```ruby
+  batch(:stats) { |users| users.to_h { |user| [user.id, Stats.for(user)] } }
+
+  attribute :stats, batch: :stats # previously required a `value:` proc
+  ```
+
 - Plugin `:presenter` — new `presenter do ... end` DSL to define presenter
   methods without reopening the `Presenter` class. The block is evaluated
   inside the serializer's own `Presenter` class; multiple blocks accumulate.

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -255,7 +255,8 @@ UserSerializer.to_h([OpenStruct.new(id: 1), OpenStruct.new(id: 2)])
 Other forms:
 
 ```ruby
-attribute :comments_count, batch: { use: :comments_count, id: :id } # explicit
+attribute :comments_count, batch: :comments_count # named loader by name (same as batch: true above)
+attribute :comments_count, batch: { use: :comments_count, id: :uuid } # hash form, only for sub-options
 attribute :comments_count, batch: { use: ->(users) { ... } } # inline loader
 
 # Multiple loaders — note the keyword is `batches:` (plural)

--- a/README.md
+++ b/README.md
@@ -410,15 +410,18 @@ class UserSerializer < Serega
   batch :comments_count, ->(users) { Comment.where(user: users).group(:user_id).count }
   batch :comments_count, CommentsCountLoader # Example with callable class
 
-  # Full attribute example
-  attribute :comments_count, batch: { use: :comments_count },
-    value: proc { |user, batch:| batch[:comments_count][user.id] }
+  # Use a loader by its name
+  attribute :comments_count, batch: :comments_count
 
-  # Shorter version
-  attribute :comments_count, batch: { use: :comments_count, id: :id } # Equivalent, id: :id is default
+  # Equivalent — when the attribute name matches the loader name
+  attribute :comments_count, batch: true
 
-  # Shortest version
-  attribute :comments_count, batch: true # Equivalent
+  # Equivalent — the default value resolution spelled out
+  attribute :comments_count, batch: :comments_count,
+    value: proc { |user, batches:| batches[:comments_count][user.id] }
+
+  # Hash form — needed only for sub-options, for example a custom `:id` method
+  attribute :comments_count, batch: { use: :comments_count, id: :uuid }
 end
 ```
 
@@ -453,7 +456,7 @@ class UserSerializer < Serega
   # Summarize likes
   attribute :likes_count,
     batch: { use: [:facebook_likes, :twitter_likes] },
-    value: proc { |user, batch:| batch[:facebook_likes][user.id] + batch[:twitter_likes][user.id] }
+    value: proc { |user, batches:| batches[:facebook_likes][user.id] + batches[:twitter_likes][user.id] }
 end
 ```
 

--- a/lib/serega/attribute_value_resolvers/batch.rb
+++ b/lib/serega/attribute_value_resolvers/batch.rb
@@ -18,6 +18,7 @@ class Serega
       # It handles this cases:
       # - `attribute :foo, batch: true`
       # - `attribute :foo, batch: FooLoader`
+      # - `attribute :foo, batch: :foo_loader`
       # - `attribute :foo, batch: { id: :foo_id }`
       # - `attribute :foo, batch: { use: FooLoader, id: foo_id }`
       # - `attribute :foo, batch: { use: :foo_loader, id: foo_id }`
@@ -31,6 +32,9 @@ class Serega
         elsif batch_opt.respond_to?(:call)          # ex: `batch: FooLoader`
           serializer_class.batch(attribute_name, batch_opt)
           batch_name = attribute_name
+          batch_id_method = default_method
+        elsif batch_opt.is_a?(Symbol) || batch_opt.is_a?(String) # ex: `batch: :foo_loader`
+          batch_name = batch_opt.to_sym
           batch_id_method = default_method
         else
           use = batch_opt[:use]

--- a/spec/serega/attribute_value_resolvers/batch_spec.rb
+++ b/spec/serega/attribute_value_resolvers/batch_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe Serega::AttributeValueResolvers do
         end
       end
 
+      context "when batch_opt is a symbol" do
+        let(:batch_opt) { :custom_loader }
+
+        it "creates resolver with the named loader and :id method" do
+          expect(resolver.instance_variable_get(:@loader_name)).to eq(:custom_loader)
+          expect(resolver.instance_variable_get(:@id_method)).to eq(batch_id_option)
+        end
+      end
+
+      context "when batch_opt is a string" do
+        let(:batch_opt) { "custom_loader" }
+
+        it "creates resolver with the named loader symbolized and :id method" do
+          expect(resolver.instance_variable_get(:@loader_name)).to eq(:custom_loader)
+          expect(resolver.instance_variable_get(:@id_method)).to eq(batch_id_option)
+        end
+      end
+
       context "when batch_opt is a hash with callable use" do
         let(:batch_opt) { {use: proc { |objects| objects.map(&:id) }} }
 

--- a/spec/serega_spec.rb
+++ b/spec/serega_spec.rb
@@ -1090,6 +1090,22 @@ RSpec.describe Serega do
       expect(block_result).to eq [1, 2]
     end
 
+    it "serializes attribute with `batch: <loader_name>` short form using default value resolution" do
+      serializer_class.batch(:stats) { |users| users.to_h { |user| [user.id, user.id * 10] } }
+      serializer_class.attribute(:likes_count, batch: :stats)
+
+      user = double(id: 1)
+      expect(serializer_class.to_h(user)).to eq(likes_count: 10)
+    end
+
+    it "serializes attribute with String `batch: <loader_name>` short form" do
+      serializer_class.batch(:stats) { |users| users.to_h { |user| [user.id, user.id * 10] } }
+      serializer_class.attribute(:likes_count, batch: "stats")
+
+      user = double(id: 2)
+      expect(serializer_class.to_h(user)).to eq(likes_count: 20)
+    end
+
     it "checks only block or only value provided" do
       # no block and no value
       expect { serializer_class.batch(:foo) }


### PR DESCRIPTION
The Symbol/String short form raised a TypeError in the default batch value resolver when the attribute had no explicit :value option (validation accepted the form, but BatchResolver assumed a Hash). Handle Symbol/String loader names in the resolver and make the short form the primary spelling in README and CHEATSHEET, keeping the hash form for sub-options.

Also fix README batch examples that used a `batch:` keyword in value procs — the actual keyword is `batches:`; the examples raised as written.