### PR TITLE
Add YARD documentation coverage check to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Markdown linter
         run: bundle exec mdl README.md CHANGELOG.md RELEASE.md
 
+      - name: Check YARD documentation coverage
+        run: |
+          bundle exec yard doc --no-cache --quiet
+          bundle exec yard stats --list-undoc | tee yard_stats.txt
+          grep -q "100.00% documented" yard_stats.txt
+
   build:
     runs-on: ubuntu-24.04
     name: Ruby ${{ matrix.ruby }} (AR ${{ matrix.activerecord }})

--- a/gemfiles/8.1.gemfile
+++ b/gemfiles/8.1.gemfile
@@ -11,6 +11,8 @@ gem "rspec", "~> 3.11", require: false
 gem "simplecov", "~> 0.22", require: false
 gem "rubocop-rake", "~> 0.6", require: false
 gem "rubocop-rspec", "~> 3.2", require: false
-gem "mdl", "~> 0.13", require: false
+gem "mdl", "~> 0.13", require: false # Markdown linter
+gem "yard", "~> 0.9", require: false # Generates and checks API documentation coverage
+gem "redcarpet", "~> 3.6", require: false # Markdown formatter used by YARD
 
 gemspec name: "serega", path: "../"

--- a/gemfiles/8.1.gemfile.lock
+++ b/gemfiles/8.1.gemfile.lock
@@ -68,6 +68,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
+    redcarpet (3.6.1)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rspec (3.13.2)
@@ -148,6 +149,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
+    yard (0.9.45)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -166,6 +168,7 @@ DEPENDENCIES
   activerecord (~> 8.1)
   mdl (~> 0.13)
   rake (~> 13.0)
+  redcarpet (~> 3.6)
   rspec (~> 3.11)
   rubocop-rake (~> 0.6)
   rubocop-rspec (~> 3.2)
@@ -173,6 +176,7 @@ DEPENDENCIES
   simplecov (~> 0.22)
   sqlite3 (~> 2.7)
   standard (~> 1.12, >= 1.12.1)
+  yard (~> 0.9)
 
 CHECKSUMS
   activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
@@ -207,6 +211,7 @@ CHECKSUMS
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
@@ -245,6 +250,7 @@ CHECKSUMS
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
 
 BUNDLED WITH
   4.0.11

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -132,11 +132,15 @@ class Serega
             superclass.modified?
           end
 
+          # Marks the class as modified, then includes the module
+          # @return [void]
           def include(*modules)
             @modified = true
             super
           end
 
+          # Marks the class as modified, then prepends the module
+          # @return [void]
           def prepend(*modules)
             @modified = true
             super


### PR DESCRIPTION
Fails the lint job when any class/method lacks a YARD doc comment. Also documents the two Presenter.include/.prepend overrides that were the only gap (100.00% documented now).