### PR TITLE
Restrict YARD docs to the public API and clean up plugin docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -3,4 +3,5 @@
 --charset utf-8
 --markup markdown
 --markup-provider redcarpet
-lib/**/*.rb'
+--no-private
+lib/**/*.rb

--- a/README.md
+++ b/README.md
@@ -749,31 +749,38 @@ handler; to use a different ORM, register your own instead.
 ```ruby
 class AppSerializer < Serega
   config.auto_preload = true
-  config.hide_by_default = false
-
   plugin :activerecord_preloads
 end
 
+class AlbumSerializer < AppSerializer
+  # no preloads
+  attribute :title
+
+  # preloads :downloads, as manually specified
+  attribute :downloads_count, preload: :downloads, value: proc { |album| album.downloads.count }
+end
+
 class UserSerializer < AppSerializer
+  # no preloads
   attribute :username
+
+  # preloads :user_stats, as auto_preload is enabled for :delegate attributes
   attribute :comments_count, delegate: { to: :user_stats }
+
+  # preloads :albums, as auto_preload is enabled for :serializer attributes
   attribute :albums, serializer: AlbumSerializer
 end
 
-class AlbumSerializer < AppSerializer
-  attribute :title
-  attribute :downloads_count, preload: :downloads,
-    value: proc { |album| album.downloads.count }
-end
-
-UserSerializer.to_h(user)
-# preloads :user_stats and :albums on the user; the AlbumSerializer level
-# preloads :downloads on the albums
+UserSerializer.to_h(users)
+# 1 query to load :user_stats for all users
+# + 1 query to load :albums for all users
+# + 1 query to load :downloads for all albums
+# = 3 queries total, regardless of how many users/albums are serialized
 ```
 
 ### Plugin :root
 
-Allows to add root key to your serialized data
+Adds a root key to serialized data.
 
 Accepts options:
 
@@ -786,56 +793,47 @@ Adds additional config options:
 - config.root.one
 - config.root.many
 - config.root.one=
-- config.root_many=
+- config.root.many=
 
 The default root is `:data`.
 
-The root key can be changed per serialization.
-
 ```ruby
- # @example Change root per serialization:
+class UserSerializer < Serega
+  plugin :root # default root is :data
+end
 
- class UserSerializer < Serega
-   plugin :root
- end
+class UserSerializer < Serega
+  plugin :root, root: :users
+end
 
- UserSerializer.to_h(nil)              # => {:data=>nil}
- UserSerializer.to_h(nil, root: :user) # => {:user=>nil}
- UserSerializer.to_h(nil, root: nil)   # => nil
+class UserSerializer < Serega
+  plugin :root, root_one: :user, root_many: :people
+end
+
+class UserSerializer < Serega
+  plugin :root, root: nil # no root key by default
+end
 ```
 
-The root key can be removed for all responses by providing the `root: nil`
-plugin option.
-
-In this case, no root key will be added. But it still can be added manually.
+The root key can also be changed per serialization, or removed entirely by
+providing `root: nil` (it can still be added back per serialization).
 
 ```ruby
- #@example Define :root plugin with different options
+class UserSerializer < Serega
+  plugin :root
+end
 
- class UserSerializer < Serega
-   plugin :root # default root is :data
- end
-
- class UserSerializer < Serega
-   plugin :root, root: :users
- end
-
- class UserSerializer < Serega
-   plugin :root, root_one: :user, root_many: :people
- end
-
- class UserSerializer < Serega
-   plugin :root, root: nil # no root key by default
- end
+UserSerializer.to_h(nil)              # => {:data=>nil}
+UserSerializer.to_h(nil, root: :user) # => {:user=>nil}
+UserSerializer.to_h(nil, root: nil)   # => nil
 ```
 
 ### Plugin :metadata
 
 Depends on: [`:root`][root] plugin, that must be loaded first
 
-Adds ability to describe metadata and adds it to serialized response
-
-Adds class-level `.meta_attribute` method. It accepts:
+Adds metadata to the serialized response via the class-level `meta_attribute`
+method, which accepts:
 
 - `*path` [Array of Symbols] - nested hash keys.
 - `**options` [Hash]
@@ -875,7 +873,8 @@ AppSerializer.to_h(nil)
 
 Depends on: [`:root`][root] plugin, that must be loaded first
 
-Allows to provide metadata and attach it to serialized response.
+Adds metadata supplied per serialization call (as opposed to `:metadata`,
+which is defined statically on the serializer).
 
 Accepts option `:context_metadata_key` with the name of the root metadata keyword.
 By default, it has the `:meta` value.
@@ -899,41 +898,39 @@ UserSerializer.to_h(nil, meta: { version: '1.0.1' })
 
 ### Plugin :formatters
 
-Allows to define `formatters` and apply them to attribute values.
+Defines named value formatters once and applies them to any attribute.
 
-Config option `config.formatters.add` can be used to add formatters.
+Use `config.formatters.add()` to register formatters. The `:format`
+attribute option then accepts a formatter name or a callable directly.
 
-Attribute option `:format` can be used with the name of formatter or with
-callable instance.
-
-Formatters can accept up to 2 parameters (formatted object, context)
+Formatters receive up to 2 parameters: the value and the context.
 
 ```ruby
 class AppSerializer < Serega
   plugin :formatters, formatters: {
-    iso8601: ->(value) { time.iso8601.round(6) },
+    iso8601: ->(value) { value.iso8601 },
     on_off: ->(value) { value ? 'ON' : 'OFF' },
-    money: ->(value, ctx) { value / 10**ctx[:digits) }
+    money: ->(value) { value.round(2) },
     date: DateTypeFormatter # callable
   }
 end
 
 class UserSerializer < Serega
-  # Additionally, we can add formatters via config in subclasses
+  # Additionally we can add formatters via config in subclasses
   config.formatters.add(
-    iso8601: ->(value) { time.iso8601.round(6) },
+    iso8601: ->(value) { value.iso8601 },
     on_off: ->(value) { value ? 'ON' : 'OFF' },
     money: ->(value) { value.round(2) }
   )
 
   # Using predefined formatter
   attribute :commission, format: :money
-  attribute :is_logined, format: :on_off
+  attribute :is_logged_in, format: :on_off
   attribute :created_at, format: :iso8601
   attribute :updated_at, format: :iso8601
 
   # Using `callable` formatter
-  attribute :score_percent, format: PercentFormmatter # callable class
+  attribute :score_percent, format: PercentFormatter # callable class
   attribute :score_percent, format: proc { |percent| "#{percent.round(2)}%" }
 end
 ```
@@ -995,12 +992,11 @@ callables keep receiving the raw objects.
 
 ### Plugin :string_modifiers
 
-Allows to specify modifiers as strings.
+Allows `:only`, `:except` and `:with` to be given as a single comma-separated
+string, with nested attributes in parentheses. Useful for accepting a field
+list straight from a query parameter.
 
-Serialized attributes must be split with `,` and nested attributes must be
-defined inside brackets `()`.
-
-Modifiers can still be provided the old way using nested hashes or arrays.
+Modifiers can still be provided the old way, as nested hashes or arrays.
 
 ```ruby
 PostSerializer.plugin :string_modifiers
@@ -1008,25 +1004,19 @@ PostSerializer.new(only: "id,user(id,username)").to_h(post)
 PostSerializer.new(except: "user(username,email)").to_h(post)
 PostSerializer.new(with: "user(email)").to_h(post)
 
-# Modifiers can still be provided the old way using nested hashes or arrays.
 PostSerializer.new(with: {user: %i[email, username]}).to_h(post)
 ```
 
 ### Plugin :if
 
-Plugin adds `:if, :unless, :if_value, :unless_value` options to
-attributes so we can remove attributes from the response in various ways.
+Adds `:if`, `:unless`, `:if_value`, `:unless_value` attribute options to
+conditionally remove attributes from the response.
 
-Use `:if` and `:unless` when you want to hide attributes before finding
-attribute value, and use `:if_value` and `:unless_value` to hide attributes
-after getting the final value.
-
-Options `:if` and `:unless` accept currently serialized object and context as
-parameters. Options `:if_value` and `:unless_value` accept already found
-serialized value and context as parameters.
-
-Options `:if_value` and `:unless_value` cannot be used with the `:serializer` option.
-Use `:if` and `:unless` in this case.
+`:if`/`:unless` receive the serialized object and context, and are checked
+before the attribute value is found. `:if_value`/`:unless_value` receive the
+already-found value and context, checked after. The latter two cannot be
+used with the `:serializer` option, since a relationship has no "serialized
+value" of its own — use `:if`/`:unless` instead.
 
 See also a `:hide` option that is available without any plugins to hide
 attribute without conditions.
@@ -1058,24 +1048,18 @@ Look at [select serialized fields](#selecting-fields) for `:hide` usage examples
 
 ### Plugin :camel_case
 
-By default, when we add an attribute like `attribute :first_name` it means:
+Without this plugin, responding with *camelCased* keys means specifying the
+attribute name and method directly for each attribute:
+`attribute :firstName, method: first_name`
 
-- adding a `:first_name` key to the resulting hash
-- adding a `#first_name` method call result as value
+This plugin camelCases every attribute name automatically, replacing `_x`
+with `X` throughout the string. The transformation runs once, when the
+attribute is defined, not on every serialization.
 
-But it's often desired to respond with *camelCased* keys.
-By default, this can be achieved by specifying the attribute name and method directly
-for each attribute: `attribute :firstName, method: first_name`
+Provide a custom transformation when adding the plugin, for example
+`plugin :camel_case, transform: ->(name) { name.camelize }`
 
-This plugin transforms all attribute names automatically.
-We use a simple regular expression to replace `_x` with `X` for the whole string.
-We make this transformation only once when the attribute is defined.
-
-You can provide custom transformation when adding the plugin,
-for example `plugin :camel_case, transform: ->(name) { name.camelize }`
-
-For any attribute camelCase-behavior can be skipped when
-the `camel_case: false` attribute option provided.
+Skip camelCase for a single attribute with `camel_case: false`.
 
 This plugin transforms only attribute keys, without affecting the `root`,
 `metadata` and `context_metadata` plugins keys.
@@ -1140,27 +1124,25 @@ end
 
 ### Plugin :explicit_many_option
 
-The plugin requires adding a `:many` option when adding relationships
-(attributes with the `:serializer` option or a block defining a nested
-serializer).
-
-Adding this plugin makes it clearer to find if some relationship is an array or
-a single object.
+Requires the `:many` option on every relationship attribute (an attribute
+with the `:serializer` option or a block defining a nested serializer), so
+it's always explicit whether it returns one object or many.
 
 ```ruby
-  class BaseSerializer < Serega
-    plugin :explicit_many_option
-  end
+class BaseSerializer < Serega
+  plugin :explicit_many_option
+  config.base_serializer = self
+end
 
-  class UserSerializer < BaseSerializer
+class PostSerializer < BaseSerializer
+  attribute :text
+
+  attribute :user, many: false do
     attribute :name
   end
 
-  class PostSerializer < BaseSerializer
-    attribute :text
-    attribute :user, serializer: UserSerializer, many: false
-    attribute :comments, serializer: PostSerializer, many: true
-  end
+  attribute :comments, serializer: PostSerializer, many: true
+end
 ```
 
 ## Errors

--- a/lib/serega.rb
+++ b/lib/serega.rb
@@ -6,10 +6,12 @@ require_relative "serega/version"
 class Serega
   # Frozen hash
   # @return [Hash] frozen hash
+  # @private
   FROZEN_EMPTY_HASH = {}.freeze
 
   # Frozen array
   # @return [Array] frozen array
+  # @private
   FROZEN_EMPTY_ARRAY = [].freeze
 
   # Empty modifiers/serialization options (used when serializing with no opts provided)
@@ -136,6 +138,7 @@ class Serega
     #
     # @return [Boolean] Is plugin used
     #
+    # @private
     def plugin_used?(name)
       plugin_name =
         case name
@@ -151,6 +154,7 @@ class Serega
     #
     # @return [Hash] attributes list
     #
+    # @private
     def attributes
       @attributes ||= {}
     end
@@ -160,6 +164,7 @@ class Serega
     #
     # @return [Hash] batch loaders list
     #
+    # @private
     def batch_loaders
       @batch_loaders ||= {}
     end
@@ -417,6 +422,7 @@ class Serega
     # This plan can be traversed to find serialized attributes and nested attributes.
     #
     # @return [Serega::SeregaPlan] Serialization plan
+    # @private
     attr_reader :plan
 
     #

--- a/lib/serega/attribute.rb
+++ b/lib/serega/attribute.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Stores serialized attribute data
   #
+  # @private
   class SeregaAttribute
     #
     # Attribute instance methods
     #
+    # @private
     module AttributeInstanceMethods
       # Attribute initial params
       # @return [Hash] Attribute initial params

--- a/lib/serega/attribute_normalizer.rb
+++ b/lib/serega/attribute_normalizer.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Prepares provided attribute options
   #
+  # @private
   class SeregaAttributeNormalizer
     #
     # AttributeNormalizer instance methods
     #
+    # @private
     module AttributeNormalizerInstanceMethods
       # Attribute initial params
       # @return [Hash] Attribute initial params

--- a/lib/serega/attribute_value_resolvers/batch.rb
+++ b/lib/serega/attribute_value_resolvers/batch.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Attribute value resolvers
   #
+  # @private
   module AttributeValueResolvers
     #
     # Builds value resolver class for attributes with :batch option
     #
+    # @private
     class BatchResolver
       #
       # Generates callable block to find attribute value when attribute with :batch
@@ -55,6 +57,7 @@ class Serega
     #
     # Builds value resolver class for attributes with :batch option
     #
+    # @private
     class Batch
       def initialize(loader_name, id_method)
         @loader_name = loader_name

--- a/lib/serega/attribute_value_resolvers/const.rb
+++ b/lib/serega/attribute_value_resolvers/const.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Attribute value resolvers
   #
+  # @private
   module AttributeValueResolvers
     #
     # Builds value resolver class for attributes with :const option
     #
+    # @private
     class ConstResolver
       #
       # Creates resolver that returns constant value
@@ -23,6 +25,7 @@ class Serega
     #
     # Value resolver class for attributes with :const option
     #
+    # @private
     class Const
       def initialize(const_value)
         @const_value = const_value

--- a/lib/serega/attribute_value_resolvers/delegate.rb
+++ b/lib/serega/attribute_value_resolvers/delegate.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Attribute value resolvers
   #
+  # @private
   module AttributeValueResolvers
     #
     # Builds value resolver class for attributes with :delegate option
     #
+    # @private
     class DelegateResolver
       #
       # Creates resolver that delegates method call to another object
@@ -25,6 +27,7 @@ class Serega
     #
     # Value resolver class for attributes with :delegate (with :allow_nil) option
     #
+    # @private
     class DelegateAllowNil
       def initialize(delegate_to, method_name)
         @delegate_to = delegate_to
@@ -49,6 +52,7 @@ class Serega
     #
     # Value resolver class for attributes with :delegate (without :allow_nil) option
     #
+    # @private
     class Delegate
       def initialize(delegate_to, method_name)
         @delegate_to = delegate_to

--- a/lib/serega/attribute_value_resolvers/hash_access.rb
+++ b/lib/serega/attribute_value_resolvers/hash_access.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module AttributeValueResolvers
     #
     # Builds value resolver for attributes with the :hash_access option
     #
+    # @private
     class HashAccessResolver
       # Allowed hash access modes
       MODES = %i[symbol string].freeze
@@ -27,6 +29,7 @@ class Serega
     # Builds value resolver for attributes with the :delegate option using
     # hash access on any of its steps
     #
+    # @private
     class HashAccessDelegateResolver
       #
       # Creates resolver that delegates through the provided step readers
@@ -45,6 +48,7 @@ class Serega
     #
     # Value resolver for attributes with the :hash_access option
     #
+    # @private
     class HashAccessKeyword
       def initialize(name, mode, allow_missing_key)
         @key = (mode == :symbol) ? name.to_sym : name.to_s
@@ -72,6 +76,7 @@ class Serega
     #
     # Value resolver for attributes with :hash_access and :delegate (without :allow_nil) options
     #
+    # @private
     class HashAccessDelegate
       def initialize(to_step, final_step)
         @to_step = to_step
@@ -92,6 +97,7 @@ class Serega
     #
     # Value resolver for attributes with :hash_access and :delegate (with :allow_nil) options
     #
+    # @private
     class HashAccessDelegateAllowNil
       def initialize(to_step, final_step)
         @to_step = to_step

--- a/lib/serega/attribute_value_resolvers/keyword.rb
+++ b/lib/serega/attribute_value_resolvers/keyword.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Attribute value resolvers
   #
+  # @private
   module AttributeValueResolvers
     #
     # Builds value resolver class for attributes with :keyword option
     #
+    # @private
     class KeywordResolver
       #
       # Creates resolver that calls method on object
@@ -23,6 +25,7 @@ class Serega
     #
     # Value resolver class for attributes with :keyword option
     #
+    # @private
     class Keyword
       def initialize(keyword)
         @keyword = keyword

--- a/lib/serega/data_builder.rb
+++ b/lib/serega/data_builder.rb
@@ -5,8 +5,10 @@ class Serega
   # Builds Data objects from serialized hashes.
   # Used by `#to_data` / `.to_data`.
   #
+  # @private
   class SeregaDataBuilder
     # SeregaDataBuilder class methods
+    # @private
     module SeregaDataBuilderClassMethods
       #
       # Converts serialized Hash/Array result into a tree of Ruby Data objects

--- a/lib/serega/engine/level.rb
+++ b/lib/serega/engine/level.rb
@@ -4,6 +4,7 @@ class Serega
   #
   # Batch feature main module
   #
+  # @private
   module SeregaEngine
     #
     # One serialization level: all objects serialized under a single plan and the
@@ -12,6 +13,7 @@ class Serega
     # or preload runs once over the whole set. A deeper level (its own plan) loads
     # separately.
     #
+    # @private
     class Level
       # @param serializer [SeregaObjectSerializer] serializer that resolves this level
       def initialize(serializer)

--- a/lib/serega/engine/level_queue.rb
+++ b/lib/serega/engine/level_queue.rb
@@ -4,6 +4,7 @@ class Serega
   #
   # Batch feature main module
   #
+  # @private
   module SeregaEngine
     #
     # Level-order queue of serialization levels for one serialization run.
@@ -15,6 +16,7 @@ class Serega
     # Processing level-by-level lets a named batch loader and preloads run once per
     # level over all of its objects.
     #
+    # @private
     class LevelQueue
       def initialize
         @levels = []

--- a/lib/serega/engine/loader.rb
+++ b/lib/serega/engine/loader.rb
@@ -4,14 +4,17 @@ class Serega
   #
   # Batch feature main module
   #
+  # @private
   module SeregaEngine
     #
     #  Batch loader
     #
+    # @private
     class Loader
       #
       # BatchLoader instance methods
       #
+      # @private
       module InstanceMethods
         # BatchLoader initial params
         # @return [Hash] BatchLoader initial params

--- a/lib/serega/helpers/serializer_class_helper.rb
+++ b/lib/serega/helpers/serializer_class_helper.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Helpers
   #
+  # @private
   module SeregaHelpers
     #
     # Stores link to current serializer class
     #
+    # @private
     module SerializerClassHelper
       # Shows serializer class current class is namespaced under
       # @return [Class<Serega>] Serializer class that current class is namespaced under.

--- a/lib/serega/object_serializer.rb
+++ b/lib/serega/object_serializer.rb
@@ -9,10 +9,12 @@ class Serega
   # which resolves every attribute for every object and enqueues child levels for
   # relations.
   #
+  # @private
   class SeregaObjectSerializer
     #
     # SeregaObjectSerializer instance methods
     #
+    # @private
     module InstanceMethods
       attr_reader :context, :plan, :many, :opts, :level_queue
 

--- a/lib/serega/plan.rb
+++ b/lib/serega/plan.rb
@@ -5,10 +5,12 @@ class Serega
   # Constructs plan - list of serialized attributes.
   # We will traverse this plan to construct serialized response.
   #
+  # @private
   class SeregaPlan
     #
     # SeregaPlan class methods
     #
+    # @private
     module ClassMethods
       #
       # Constructs plan of attributes that should be serialized.
@@ -68,6 +70,7 @@ class Serega
     #
     # SeregaPlan instance methods
     #
+    # @private
     module InstanceMethods
       # Parent plan point
       # @return [SeregaPlanPoint, nil]

--- a/lib/serega/plan_point.rb
+++ b/lib/serega/plan_point.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Combines attribute and nested attributes
   #
+  # @private
   class SeregaPlanPoint
     #
     # SeregaPlanPoint instance methods
     #
+    # @private
     module InstanceMethods
       # Link to current plan this point belongs to
       # @return [SeregaAttribute] Current plan

--- a/lib/serega/plugins.rb
+++ b/lib/serega/plugins.rb
@@ -17,6 +17,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def register_plugin(name, mod)
         @plugins[name] = mod
       end
@@ -36,6 +37,7 @@ class Serega
       #
       # @return [Class<Module>] Plugin core module
       #
+      # @private
       def find_plugin(name)
         return name if name.is_a?(Module)
         return @plugins[name] if @plugins.key?(name)

--- a/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
+++ b/lib/serega/plugins/activerecord_preloads/activerecord_preloads.rb
@@ -12,38 +12,40 @@ class Serega
     #
     # @example
     #   class AppSerializer < Serega
-    #     config.auto_preload_attributes_with_delegate = true
-    #     config.auto_preload_attributes_with_serializer = true
-    #     config.hide_by_default = [:preload]
-    #
+    #     config.auto_preload = true
     #     plugin :activerecord_preloads
-    #   end
-    #
-    #   class UserSerializer < AppSerializer
-    #     # no preloads
-    #     attribute :username
-    #
-    #     # preloads `:user_stats` as auto_preload_attributes_with_delegate option is true
-    #     attribute :comments_count, delegate: { to: :user_stats }
-    #
-    #     # preloads `:albums` as auto_preload_attributes_with_serializer option is true
-    #     attribute :albums, serializer: AlbumSerializer, hide: false
     #   end
     #
     #   class AlbumSerializer < AppSerializer
     #     # no preloads
     #     attribute :title
     #
-    #     # preloads :downloads_count as manually specified
+    #     # preloads :downloads, as manually specified
     #     attribute :downloads_count, preload: :downloads, value: proc { |album| album.downloads.count }
     #   end
     #
-    #   UserSerializer.to_h(user)
+    #   class UserSerializer < AppSerializer
+    #     # no preloads
+    #     attribute :username
+    #
+    #     # preloads :user_stats, as auto_preload is enabled for :delegate attributes
+    #     attribute :comments_count, delegate: { to: :user_stats }
+    #
+    #     # preloads :albums, as auto_preload is enabled for :serializer attributes
+    #     attribute :albums, serializer: AlbumSerializer
+    #   end
+    #
+    #   UserSerializer.to_h(users)
+    #   # 1 query to load :user_stats for all users
+    #   # + 1 query to load :albums for all users
+    #   # + 1 query to load :downloads for all albums
+    #   # = 3 queries total, regardless of how many users/albums are serialized
     #
     module ActiverecordPreloads
       #
       # @return [Symbol] Plugin name
       #
+      # @private
       def self.plugin_name
         :activerecord_preloads
       end
@@ -55,6 +57,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         opts.each_key do |key|
           raise SeregaError, "Plugin #{plugin_name.inspect} does not accept the #{key.inspect} option. No options are allowed"
@@ -69,6 +72,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         require_relative "lib/preloader"
       end
@@ -81,6 +85,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **_opts)
         serializer_class.preload_with do |objects, preloads|
           Preloader.preload(ActiverecordPreloads.records(serializer_class, objects), preloads)
@@ -98,6 +103,7 @@ class Serega
       #
       # @return [Array] the underlying records
       #
+      # @private
       def self.records(serializer_class, objects)
         return objects unless serializer_class.plugin_used?(:presenter)
         return objects unless serializer_class.custom_presenter?

--- a/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
+++ b/lib/serega/plugins/activerecord_preloads/lib/preloader.rb
@@ -4,6 +4,7 @@ class Serega
   module SeregaPlugins
     module ActiverecordPreloads
       # Handles preloads for different types of initial records
+      # @private
       class Preloader
         class << self
           # Preloads associations to records
@@ -37,6 +38,7 @@ class Serega
       end
 
       # Associations loader for prepared records
+      # @private
       class Loader
         # :nocov: We can check only one version of activerecord
 
@@ -58,6 +60,7 @@ class Serega
       end
 
       # Preloader adapter for ActiveRecord object
+      # @private
       class ActiverecordObject
         class << self
           #
@@ -84,6 +87,7 @@ class Serega
       end
 
       # Preloader adapter for ActiveRecord::Relation
+      # @private
       class ActiverecordRelation
         class << self
           #
@@ -111,6 +115,7 @@ class Serega
       end
 
       # Preloader adapter for Array of ActiveRecord objects
+      # @private
       class ActiverecordArray
         class << self
           #
@@ -146,6 +151,7 @@ class Serega
       end
 
       # Preloader adapter for Enumerator with ActiveRecord objects
+      # @private
       class ActiverecordEnumerator
         class << self
           #

--- a/lib/serega/plugins/camel_case/camel_case.rb
+++ b/lib/serega/plugins/camel_case/camel_case.rb
@@ -5,21 +5,14 @@ class Serega
     #
     # Plugin :camel_case
     #
-    # By default when we add attribute like `attribute :first_name` this means:
-    # - adding a `:first_name` key to resulted hash
-    # - adding a `#first_name` method call result as value
+    # CamelCases every attribute name automatically, replacing `_x` with `X`
+    # throughout the string. Runs once, when the attribute is defined, not on
+    # every serialization.
     #
-    # But its often desired to response with *camelCased* keys.
-    # Earlier this can be achieved by specifying attribute name and method directly
-    # for each attribute: `attribute :firstName, method: first_name`
+    # Provide a custom transformation with
+    # `plugin :camel_case, transform: ->(name) { name.camelize }`.
     #
-    # Now this plugin transforms all attribute names automatically.
-    # We use simple regular expression to replace `_x` to `X` for the whole string.
-    # You can provide your own callable transformation when defining plugin,
-    # for example `plugin :camel_case, transform: ->(name) { name.camelize }`
-    #
-    # For any attribute camelCase-behavior can be skipped when
-    # `camel_case: false` attribute option provided.
+    # Skip camelCase for a single attribute with `camel_case: false`.
     #
     # @example Define plugin
     #  class AppSerializer < Serega
@@ -44,6 +37,7 @@ class Serega
       }
 
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :camel_case
       end
@@ -55,6 +49,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         allowed_keys = %i[transform]
         opts.each_key do |key|
@@ -74,6 +69,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class::SeregaConfig.include(ConfigInstanceMethods)
         serializer_class::SeregaAttributeNormalizer.include(AttributeNormalizerInstanceMethods)
@@ -88,6 +84,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         config = serializer_class.config
         config.opts[:camel_case] = {}
@@ -113,6 +110,7 @@ class Serega
       #
       # @see Serega::SeregaValidations::CheckAttributeParams
       #
+      # @private
       module CheckAttributeParamsInstanceMethods
         private
 
@@ -125,6 +123,7 @@ class Serega
       #
       # Validator for attribute :camel_case option
       #
+      # @private
       class CheckOptCamelCase
         class << self
           #
@@ -191,6 +190,7 @@ class Serega
       #
       # @see SeregaAttributeNormalizer::AttributeInstanceMethods
       #
+      # @private
       module AttributeNormalizerInstanceMethods
         private
 

--- a/lib/serega/plugins/context_metadata/context_metadata.rb
+++ b/lib/serega/plugins/context_metadata/context_metadata.rb
@@ -7,7 +7,8 @@ class Serega
     #
     # Depends on: `:root` plugin, that must be loaded first
     #
-    # Allows to specify metadata to be added to serialized response.
+    # Adds metadata supplied per serialization call (as opposed to `:metadata`,
+    # which is defined statically on the serializer).
     #
     # @example
     #   class UserSerializer < Serega
@@ -23,6 +24,7 @@ class Serega
       DEFAULT_CONTEXT_METADATA_KEY = :meta
 
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :context_metadata
       end
@@ -34,6 +36,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         allowed_keys = %i[context_metadata_key]
         opts.each_key do |key|
@@ -57,6 +60,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.include(InstanceMethods)
         serializer_class::SeregaConfig.include(ConfigInstanceMethods)
@@ -71,6 +75,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         config = serializer_class.config
         meta_key = opts[:context_metadata_key] || DEFAULT_CONTEXT_METADATA_KEY
@@ -127,6 +132,7 @@ class Serega
       #
       # @see Serega::SeregaValidations::CheckSerializeParams
       #
+      # @private
       module CheckSerializeParamsInstanceMethods
         private
 
@@ -143,6 +149,7 @@ class Serega
       #
       # @see Serega
       #
+      # @private
       module InstanceMethods
         private
 

--- a/lib/serega/plugins/depth_limit/depth_limit.rb
+++ b/lib/serega/plugins/depth_limit/depth_limit.rb
@@ -5,25 +5,23 @@ class Serega
     #
     # Plugin :depth_limit
     #
-    # Helps to secure from malicious queries that require to serialize too much
-    # or from accidental serializing of objects with cyclic relations.
+    # Guards against malicious queries that serialize too much, or against
+    # accidentally serializing objects with cyclic relations.
     #
-    # Depth limit is checked when constructing a serialization plan, that is when
-    # `#new` method is called, ex: `SomeSerializer.new(with: params[:with])`.
-    # It can be useful to instantiate serializer before any other business logic
-    # to get possible errors earlier.
+    # Depth limit is checked when a serialization plan is built, i.e. when
+    # `#new` is called (`SomeSerializer.new(with: params[:with])`) — including
+    # internally by every class-level serialization method. Instantiating the
+    # serializer early surfaces depth errors sooner.
     #
-    # Any class-level serialization methods also check depth limit as they also instantiate serializer.
+    # When the limit is exceeded, `Serega::DepthLimitError` is raised;
+    # details are available via `Serega::DepthLimitError#details`.
     #
-    # When depth limit is exceeded `Serega::DepthLimitError` is raised.
-    # Depth limit error details can be found in additional `Serega::DepthLimitError#details` method
-    #
-    # Limit can be checked or changed with next config options:
+    # Limit can be checked or changed with config options:
     #
     #   - config.depth_limit.limit
     #   - config.depth_limit.limit=
     #
-    # There are no default limit, but it should be set when enabling plugin.
+    # There is no default limit — it must be set when enabling the plugin.
     #
     # @example
     #
@@ -37,6 +35,7 @@ class Serega
     #
     module DepthLimit
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :depth_limit
       end
@@ -48,6 +47,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         allowed_keys = %i[limit]
         opts.each_key do |key|
@@ -67,6 +67,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class::SeregaPlan.include(PlanInstanceMethods)
         serializer_class::SeregaConfig.include(ConfigInstanceMethods)
@@ -80,6 +81,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         config = serializer_class.config
         limit = opts.fetch(:limit) { raise SeregaError, "Please provide :limit option. Example: `plugin :depth_limit, limit: 10`" }
@@ -137,6 +139,7 @@ class Serega
       #
       # @see SeregaPlan
       #
+      # @private
       module PlanInstanceMethods
         #
         # Initializes serialization plan

--- a/lib/serega/plugins/explicit_many_option/explicit_many_option.rb
+++ b/lib/serega/plugins/explicit_many_option/explicit_many_option.rb
@@ -5,29 +5,29 @@ class Serega
     #
     # Plugin :explicit_many_option
     #
-    # Plugin requires to add :many option when adding relationships
-    # (relationships are attributes with the :serializer option or a block
-    # defining a nested serializer)
-    #
-    # Adding this plugin makes it clearer to find if relationship returns array or single object
+    # Requires the `:many` option on every relationship attribute (an
+    # attribute with the `:serializer` option or a block defining a nested
+    # serializer), so it's always explicit whether it returns one object or many.
     #
     # @example
     #   class BaseSerializer < Serega
     #     plugin :explicit_many_option
-    #   end
-    #
-    #   class UserSerializer < BaseSerializer
-    #     attribute :name
+    #     config.base_serializer = self
     #   end
     #
     #   class PostSerializer < BaseSerializer
     #     attribute :text
-    #     attribute :user, serializer: UserSerializer, many: false
+    #
+    #     attribute :user, many: false do
+    #       attribute :name
+    #     end
+    #
     #     attribute :comments, serializer: PostSerializer, many: true
     #   end
     #
     module ExplicitManyOption
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :explicit_many_option
       end
@@ -40,6 +40,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         require_relative "validations/check_opt_many"
 
@@ -51,6 +52,7 @@ class Serega
       #
       # @see Serega::SeregaValidations::CheckAttributeParams
       #
+      # @private
       module CheckAttributeParamsInstanceMethods
         private
 

--- a/lib/serega/plugins/explicit_many_option/validations/check_opt_many.rb
+++ b/lib/serega/plugins/explicit_many_option/validations/check_opt_many.rb
@@ -6,6 +6,7 @@ class Serega
       #
       # Validator for attribute :many option
       #
+      # @private
       class CheckOptMany
         class << self
           #

--- a/lib/serega/plugins/formatters/formatters.rb
+++ b/lib/serega/plugins/formatters/formatters.rb
@@ -5,20 +5,19 @@ class Serega
     #
     # Plugin :formatters
     #
-    # Allows to define value formatters one time and apply them on any attributes.
+    # Defines named value formatters once and applies them to any attribute.
     #
-    # Config option `config.formatters.add()` can be used to add formatters.
+    # Use `config.formatters.add()` to register formatters. The `:format`
+    # attribute option then accepts a formatter name or a callable directly.
     #
-    # Attribute option `:format` now can be used with name of formatter or with callable instance.
-    #
-    # Formatters can accept up to 2 parameters (formatted object, context)
+    # Formatters receive up to 2 parameters: the value and the context.
     #
     # @example
     #   class AppSerializer < Serega
     #     plugin :formatters, formatters: {
-    #       iso8601: ->(value) { time.iso8601.round(6) },
+    #       iso8601: ->(value) { value.iso8601 },
     #       on_off: ->(value) { value ? 'ON' : 'OFF' },
-    #       money: ->(value) { value.round(2) }
+    #       money: ->(value) { value.round(2) },
     #       date: DateTypeFormatter # callable
     #     }
     #   end
@@ -26,24 +25,25 @@ class Serega
     #   class UserSerializer < Serega
     #     # Additionally we can add formatters via config in subclasses
     #     config.formatters.add(
-    #       iso8601: ->(value) { time.iso8601.round(6) },
+    #       iso8601: ->(value) { value.iso8601 },
     #       on_off: ->(value) { value ? 'ON' : 'OFF' },
     #       money: ->(value) { value.round(2) }
     #     )
     #
     #     # Using predefined formatter
     #     attribute :commission, format: :money
-    #     attribute :is_logined, format: :on_off
+    #     attribute :is_logged_in, format: :on_off
     #     attribute :created_at, format: :iso8601
     #     attribute :updated_at, format: :iso8601
     #
     #     # Using `callable` formatter
-    #     attribute :score_percent, format: PercentFormmatter # callable class
+    #     attribute :score_percent, format: PercentFormatter # callable class
     #     attribute :score_percent, format: proc { |percent| "#{percent.round(2)}%" }
     #   end
     #
     module Formatters
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :formatters
       end
@@ -55,6 +55,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         allowed_keys = %i[formatters]
         opts.each_key do |key|
@@ -74,6 +75,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class::SeregaConfig.include(ConfigInstanceMethods)
         serializer_class::SeregaAttributeNormalizer.include(AttributeNormalizerInstanceMethods)
@@ -89,6 +91,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         config = serializer_class.config
         config.opts[:formatters] = {}
@@ -141,6 +144,7 @@ class Serega
       #
       # @see Serega::SeregaValidations::CheckAttributeParams
       #
+      # @private
       module CheckAttributeParamsInstanceMethods
         private
 
@@ -156,6 +160,7 @@ class Serega
       #
       # @see SeregaAttributeNormalizer
       #
+      # @private
       module AttributeNormalizerInstanceMethods
         # Block or callable instance that will format attribute values
         # @return [Proc, #call, nil] Block or callable instance that will format attribute values
@@ -194,6 +199,7 @@ class Serega
       #
       # @see SeregaAttribute
       #
+      # @private
       module AttributeInstanceMethods
         #
         # Returns formatted attribute value
@@ -229,6 +235,7 @@ class Serega
       #
       # Validator for attribute :format option
       #
+      # @private
       class CheckOptFormat
         class << self
           #
@@ -265,6 +272,7 @@ class Serega
       #
       # Validator for formatters defined as config options or directly as attribute :format option
       #
+      # @private
       class CheckFormatter
         class << self
           #

--- a/lib/serega/plugins/if/if.rb
+++ b/lib/serega/plugins/if/if.rb
@@ -3,46 +3,34 @@
 class Serega
   module SeregaPlugins
     #
-    # Plugin adds `:if`, `:unless`, `:if_value`, `:unless_value` options to
-    # attributes so we can remove attributes from response in various ways.
+    # Plugin :if
     #
-    # Use `:if` and `:unless` when you want to hide attributes before finding attribute value,
-    # and use `:if_value` and `:unless_value` to hide attributes after we find final value.
+    # Adds `:if`, `:unless`, `:if_value`, `:unless_value` attribute options to
+    # conditionally remove attributes from the response.
     #
-    # Options `:if` and `:unless` accept currently serialized object and context as parameters.
-    # Options `:if_value` and `:unless_value` accept already found serialized value and context as parameters.
+    # `:if`/`:unless` receive the serialized object and context, and are
+    # checked before the attribute value is found. `:if_value`/`:unless_value`
+    # receive the already-found value and context, checked after. The latter
+    # two cannot be used with the `:serializer` option, since a relationship
+    # has no "serialized value" of its own — use `:if`/`:unless` instead.
     #
-    # Options `:if_value` and `:unless_value` cannot be used with :serializer option, as
-    # serialized objects have no "serialized value". Use `:if` and `:unless` in this case.
+    # See also the plugin-free `:hide` option (README.md#selecting-fields),
+    # which hides an attribute unconditionally.
     #
-    # See also a `:hide` option that is available without any plugins to hide
-    # attribute without conditions. Look at README.md#selecting-fields for `:hide` usage examples.
+    # @example
+    #   class UserSerializer < Serega
+    #     attribute :email, if: :active? # if user.active?
+    #     attribute :email, if: proc { |user, ctx| user == ctx[:current_user] } # using context
+    #     attribute :email, if: CustomPolicy.method(:view_email?) # any callable
     #
-    # Examples:
-    #  class UserSerializer < Serega
-    #    attribute :email, if: :active? # if user.active?
-    #    attribute :email, if: proc {|user| user.active?} # same
-    #    attribute :email, if: proc {|user, ctx| user == ctx[:current_user]} # using context
-    #    attribute :email, if: CustomPolicy.method(:view_email?) # You can provide own callable object
-    #
-    #    attribute :email, unless: :hidden? # unless user.hidden?
-    #    attribute :email, unless: proc {|user| user.hidden?} # same
-    #    attribute :email, unless: proc {|user, context| context[:show_emails]} # using context
-    #    attribute :email, unless: CustomPolicy.method(:hide_email?) # You can provide own callable object
-    #
-    #    attribute :email, if_value: :present? # if email.present?
-    #    attribute :email, if_value: proc {|email| email.present?} # same
-    #    attribute :email, if_value: proc {|email, ctx| ctx[:show_emails]} # using context
-    #    attribute :email, if_value: CustomPolicy.method(:view_email?) # You can provide own callable object
-    #
-    #    attribute :email, unless_value: :blank? # unless email.blank?
-    #    attribute :email, unless_value: proc {|email| email.blank?} # same
-    #    attribute :email, unless_value: proc {|email, context| context[:show_emails]} # using context
-    #    attribute :email, unless_value: CustomPolicy.method(:hide_email?) # You can provide own callable object
-    #  end
+    #     attribute :email, unless: :hidden? # unless user.hidden?
+    #     attribute :email, if_value: :present? # if email.present?
+    #     attribute :email, unless_value: :blank? # unless email.blank?
+    #   end
     #
     module If
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :if
       end
@@ -55,6 +43,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         require_relative "validations/check_opt_if"
         require_relative "validations/check_opt_if_value"
@@ -77,6 +66,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         serializer_class.config.attribute_keys << :if << :if_value << :unless << :unless_value
       end
@@ -86,6 +76,7 @@ class Serega
       #
       # @see SeregaAttributeNormalizer::AttributeInstanceMethods
       #
+      # @private
       module AttributeNormalizerInstanceMethods
         #
         # Returns prepared attribute :if_options.
@@ -135,6 +126,7 @@ class Serega
       #
       # Resolves keyword-based conditions for if/unless options
       #
+      # @private
       class KeywordConditionResolver
         def initialize(keyword)
           @keyword = keyword
@@ -156,6 +148,7 @@ class Serega
       #
       # @see Serega::SeregaAttribute
       #
+      # @private
       module AttributeInstanceMethods
         # @return [Hash] provided :if options
         attr_reader :opt_if
@@ -177,6 +170,7 @@ class Serega
       #
       # @see Serega::SeregaPlanPoint::InstanceMethods
       #
+      # @private
       module PlanPointInstanceMethods
         #
         # @return [Boolean] Should we show attribute or not
@@ -225,6 +219,7 @@ class Serega
       #
       # @see Serega::SeregaValidations::CheckAttributeParams
       #
+      # @private
       module CheckAttributeParamsInstanceMethods
         private
 
@@ -247,6 +242,7 @@ class Serega
       #
       # @see Serega::SeregaDataBuilder
       #
+      # @private
       module DataBuilderClassMethods
         private
 
@@ -264,6 +260,7 @@ class Serega
       #
       # @see Serega::SeregaObjectSerializer
       #
+      # @private
       module ObjectSerializerInstanceMethods
         private
 

--- a/lib/serega/plugins/if/validations/check_opt_if.rb
+++ b/lib/serega/plugins/if/validations/check_opt_if.rb
@@ -6,6 +6,7 @@ class Serega
       #
       # Validator for attribute :if option
       #
+      # @private
       class CheckOptIf
         class << self
           #

--- a/lib/serega/plugins/if/validations/check_opt_if_value.rb
+++ b/lib/serega/plugins/if/validations/check_opt_if_value.rb
@@ -6,6 +6,7 @@ class Serega
       #
       # Validator for attribute :if_value option
       #
+      # @private
       class CheckOptIfValue
         class << self
           #

--- a/lib/serega/plugins/if/validations/check_opt_unless.rb
+++ b/lib/serega/plugins/if/validations/check_opt_unless.rb
@@ -6,6 +6,7 @@ class Serega
       #
       # Validator for attribute :unless option
       #
+      # @private
       class CheckOptUnless
         class << self
           #

--- a/lib/serega/plugins/if/validations/check_opt_unless_value.rb
+++ b/lib/serega/plugins/if/validations/check_opt_unless_value.rb
@@ -6,6 +6,7 @@ class Serega
       #
       # Validator for attribute :unless_value option
       #
+      # @private
       class CheckOptUnlessValue
         class << self
           #

--- a/lib/serega/plugins/metadata/meta_attribute.rb
+++ b/lib/serega/plugins/metadata/meta_attribute.rb
@@ -6,10 +6,12 @@ class Serega
       #
       # Stores Attribute data
       #
+      # @private
       class MetaAttribute
         #
         # Stores Attribute instance methods
         #
+        # @private
         module InstanceMethods
           # @return [Symbol] Meta attribute name
           attr_reader :name

--- a/lib/serega/plugins/metadata/metadata.rb
+++ b/lib/serega/plugins/metadata/metadata.rb
@@ -3,23 +3,20 @@
 class Serega
   module SeregaPlugins
     #
-    # Plugin `:metadata`
+    # Plugin :metadata
     #
     # Depends on: `:root` plugin, that must be loaded first
     #
-    # Adds ability to describe metadata that must be added to serialized response
+    # Adds metadata to the serialized response via the class-level
+    # `meta_attribute` method, which accepts:
     #
-    # Added class-level method `:meta_attribute`, to define metadata, it accepts:
-    #
-    # - `*path` [Array of Symbols] - nested hash keys.
+    # - `*path` [Array<Symbol>] - nested hash keys
     # - `**options` [Hash]
-    #
-    #   - `:const` - describes metadata value (if it is constant)
-    #   - `:value` - describes metadata value as any `#callable` instance
-    #   - `:hide_nil` - does not show metadata key if value is nil, `false` by default
-    #   - `:hide_empty`, does not show metadata key if value is nil or empty, `false` by default
-    #
-    # - `&block` [Proc] - describes value for current meta attribute
+    #   - `:const` - a constant metadata value
+    #   - `:value` - a `#callable` producing the metadata value
+    #   - `:hide_nil` - hide the key if the value is nil (`false` by default)
+    #   - `:hide_empty` - hide the key if the value is nil or empty (`false` by default)
+    # - `&block` - computes the value for this meta attribute
     #
     # @example
     #  class AppSerializer < Serega
@@ -39,6 +36,7 @@ class Serega
     #
     module Metadata
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :metadata
       end
@@ -50,6 +48,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **_opts)
         unless serializer_class.plugin_used?(:root)
           raise SeregaError, "Plugin #{plugin_name.inspect} must be loaded after the :root plugin. Please load the :root plugin first"
@@ -64,6 +63,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
         serializer_class.include(InstanceMethods)
@@ -91,6 +91,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **_opts)
         serializer_class.config.opts[:metadata] = {attribute_keys: %i[const hide_nil hide_empty value]}
       end
@@ -183,6 +184,7 @@ class Serega
       #
       # @see Serega
       #
+      # @private
       module InstanceMethods
         private
 

--- a/lib/serega/plugins/metadata/validations/check_block.rb
+++ b/lib/serega/plugins/metadata/validations/check_block.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute block parameter
         #
+        # @private
         class CheckBlock
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_opt_const.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_const.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # MetaAttribute `:const` option validator
         #
+        # @private
         class CheckOptConst
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_empty.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute :hide_empty option
         #
+        # @private
         class CheckOptHideEmpty
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_hide_nil.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute :hide_nil option
         #
+        # @private
         class CheckOptHideNil
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_opt_value.rb
+++ b/lib/serega/plugins/metadata/validations/check_opt_value.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute :value option
         #
+        # @private
         class CheckOptValue
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_opts.rb
+++ b/lib/serega/plugins/metadata/validations/check_opts.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute options
         #
+        # @private
         class CheckOpts
           class << self
             #

--- a/lib/serega/plugins/metadata/validations/check_path.rb
+++ b/lib/serega/plugins/metadata/validations/check_path.rb
@@ -7,6 +7,7 @@ class Serega
         #
         # Validator for meta_attribute :path parameter
         #
+        # @private
         class CheckPath
           # Regexp for valid path
           FORMAT = /\A[\w~-]+\z/

--- a/lib/serega/plugins/presenter/presenter.rb
+++ b/lib/serega/plugins/presenter/presenter.rb
@@ -15,12 +15,10 @@ class Serega
     # - The original object is accessible via __getobj__ (standard SimpleDelegator API).
     # - The serialization context is accessible via the private method __ctx__.
     #
-    # Objects are wrapped in the Presenter only when the serializer's Presenter
-    # class (or an inherited one) was actually extended with custom methods —
-    # a bare `plugin :presenter` adds no wrapping overhead. The check is
-    # denormalized: `SerializerClass.custom_presenter?` is asked once per
-    # object serializer and the result is reused for the whole level.
+    # The `presenter do ... end` block is evaluated inside the serializer's own
+    # Presenter class, so multiple blocks accumulate.
     #
+    # @example
     #   class UserSerializer < Serega
     #     plugin :presenter
     #
@@ -38,10 +36,9 @@ class Serega
     #     end
     #   end
     #
-    # The `presenter do ... end` block is evaluated inside the serializer's own
-    # Presenter class, so multiple blocks accumulate.
     module Presenter
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :presenter
       end
@@ -54,6 +51,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
         serializer_class::SeregaObjectSerializer.include(SeregaObjectSerializerInstanceMethods)
@@ -67,6 +65,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **_opts)
         presenter_class = Class.new(Presenter)
         presenter_class.serializer_class = serializer_class
@@ -79,8 +78,10 @@ class Serega
       end
 
       # Presenter class
+      # @private
       class Presenter < SimpleDelegator
         # Presenter instance methods
+        # @private
         module InstanceMethods
           #
           # @param object [Object] Serialized object to wrap
@@ -187,6 +188,7 @@ class Serega
         #
         # @return [Boolean] whether custom presenter methods were defined
         #
+        # @private
         def custom_presenter?
           self::Presenter.modified?
         end
@@ -207,6 +209,7 @@ class Serega
       #
       # @see Serega::SeregaObjectSerializer
       #
+      # @private
       module SeregaObjectSerializerInstanceMethods
         # The custom-presenter check is made once per object serializer here
         # and its result is reused for every enqueued chunk of the level.

--- a/lib/serega/plugins/root/root.rb
+++ b/lib/serega/plugins/root/root.rb
@@ -5,7 +5,7 @@ class Serega
     #
     # Plugin :root
     #
-    # Allows to add root key to your serialized data
+    # Adds a root key to serialized data.
     #
     # Accepts options:
     #  - :root - specifies root for all responses
@@ -16,14 +16,12 @@ class Serega
     #   - config.root.one
     #   - config.root.many
     #   - config.root.one=
-    #   - config.root_many=
+    #   - config.root.many=
     #
     # Default root is `:data`.
     #
-    # Root also can be changed per serialization.
-    #
-    # Also root can be removed for all responses by providing `root: nil`. In this case no root will be added to response, but
-    # you still can to add it per serialization
+    # Root can also be changed per serialization, or removed entirely by
+    # providing `root: nil` (per serialization it can still be added back).
     #
     # @example Define plugin
     #   class UserSerializer < Serega
@@ -56,6 +54,7 @@ class Serega
       ROOT_DEFAULT = :data
 
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :root
       end
@@ -67,6 +66,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.before_load_plugin(serializer_class, **opts)
         allowed_keys = %i[root root_one root_many]
         opts.each_key do |key|
@@ -88,6 +88,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.extend(ClassMethods)
         serializer_class.include(InstanceMethods)
@@ -103,6 +104,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.after_load_plugin(serializer_class, **opts)
         config = serializer_class.config
         default = opts.fetch(:root, ROOT_DEFAULT)
@@ -214,6 +216,7 @@ class Serega
       #
       # @see Serega
       #
+      # @private
       module InstanceMethods
         #
         # Serializes provided object to a tree of Ruby Data objects.
@@ -261,6 +264,7 @@ class Serega
       #
       # @see Serega::SeregaDataBuilder
       #
+      # @private
       module DataBuilderClassMethods
         #
         # @param serializer [Serega] Serializer instance carrying the plan

--- a/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
+++ b/lib/serega/plugins/string_modifiers/parse_string_modifiers.rb
@@ -22,6 +22,7 @@ class Serega
       #
       # Modifiers parser
       #
+      # @private
       class ParseStringModifiers
         COMMA = ","
         COMMA_CODEPOINT = COMMA.ord

--- a/lib/serega/plugins/string_modifiers/string_modifiers.rb
+++ b/lib/serega/plugins/string_modifiers/string_modifiers.rb
@@ -2,8 +2,27 @@
 
 class Serega
   module SeregaPlugins
+    #
+    # Plugin :string_modifiers
+    #
+    # Allows `:only`, `:except` and `:with` to be given as a single comma-separated
+    # string, with nested attributes in parentheses. Useful for accepting a field
+    # list straight from a query parameter.
+    #
+    # @example
+    #   class UserSerializer < Serega
+    #     plugin :string_modifiers
+    #
+    #     attribute :username
+    #     attribute :first_name
+    #     attribute :addresses, serializer: AddressSerializer, hide: true
+    #   end
+    #
+    #   UserSerializer.to_h(user, only: "username,addresses(line1,line2)")
+    #
     module StringModifiers
       # @return [Symbol] Plugin name
+      # @private
       def self.plugin_name
         :string_modifiers
       end
@@ -16,6 +35,7 @@ class Serega
       #
       # @return [void]
       #
+      # @private
       def self.load_plugin(serializer_class, **_opts)
         serializer_class.include(InstanceMethods)
         require_relative "parse_string_modifiers"
@@ -26,6 +46,7 @@ class Serega
       #
       # @see Serega
       #
+      # @private
       module InstanceMethods
         private
 

--- a/lib/serega/utils/collection_detector.rb
+++ b/lib/serega/utils/collection_detector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaUtils
     #
     # Utility to check if an object should be serialized as a collection.
@@ -8,6 +9,7 @@ class Serega
     # Hashes and Structs are Enumerable, but enumerate their own member
     # values, so they are treated as single objects.
     #
+    # @private
     class CollectionDetector
       class << self
         #

--- a/lib/serega/utils/enum_deep_dup.rb
+++ b/lib/serega/utils/enum_deep_dup.rb
@@ -4,11 +4,13 @@ class Serega
   #
   # Utilities
   #
+  # @private
   module SeregaUtils
     #
     # Duplicates nested hashes and arrays
     # It does not duplicate any non-Array and non-Hash values
     #
+    # @private
     class EnumDeepDup
       class << self
         #

--- a/lib/serega/utils/enum_deep_freeze.rb
+++ b/lib/serega/utils/enum_deep_freeze.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Utilities
   #
+  # @private
   module SeregaUtils
     #
     # Utility to freeze nested hashes and arrays
     #
+    # @private
     class EnumDeepFreeze
       class << self
         #

--- a/lib/serega/utils/method_signature.rb
+++ b/lib/serega/utils/method_signature.rb
@@ -4,10 +4,12 @@ class Serega
   #
   # Utilities
   #
+  # @private
   module SeregaUtils
     #
     # Utility to make method arguments signature
     #
+    # @private
     class MethodSignature
       SYMBOL_TO_PROC_SIGNATURE_RUBY2 = [[:rest]]
       SYMBOL_TO_PROC_SIGNATURE_RUBY3 = [[:req], [:rest]]

--- a/lib/serega/utils/serialized_attribute_error.rb
+++ b/lib/serega/utils/serialized_attribute_error.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaUtils
     #
     # Reraises an error, adding which attribute and serializer were being
@@ -8,6 +9,7 @@ class Serega
     # and the batch attach phase so the message stays identical for every
     # attribute, whether its value is resolved inline or during batch loading.
     #
+    # @private
     module SerializedAttributeError
       module_function
 

--- a/lib/serega/utils/symbol_name.rb
+++ b/lib/serega/utils/symbol_name.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaUtils
     #
     # Utility to get frozen string from symbol in any ruby version
     #
+    # @private
     class SymbolName
       class << self
         #

--- a/lib/serega/utils/to_hash.rb
+++ b/lib/serega/utils/to_hash.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaUtils
     #
     # Utility to transform almost anything to Hash
     #
+    # @private
     class ToHash
       class << self
         #

--- a/lib/serega/validations/attribute/check_block.rb
+++ b/lib/serega/validations/attribute/check_block.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Attribute parameters validators
     #
+    # @private
     module Attribute
       #
       # Attribute `block` parameter validator
       #
+      # @private
       class CheckBlock
         # Explains the changed attribute block behavior. Shown when the block
         # looks like an old-style value block — it accepts parameters or

--- a/lib/serega/validations/attribute/check_name.rb
+++ b/lib/serega/validations/attribute/check_name.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `name` parameter validator
       #
+      # @private
       class CheckName
         # Regexp for valid attribute name
         FORMAT = /\A[\w~-]+\z/

--- a/lib/serega/validations/attribute/check_opt_base_serializer.rb
+++ b/lib/serega/validations/attribute/check_opt_base_serializer.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:base_serializer` option validator
       #
+      # @private
       class CheckOptBaseSerializer
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_batch.rb
+++ b/lib/serega/validations/attribute/check_opt_batch.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:batch` option validator
       #
+      # @private
       class CheckOptBatch
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_const.rb
+++ b/lib/serega/validations/attribute/check_opt_const.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:const` option validator
       #
+      # @private
       class CheckOptConst
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_delegate.rb
+++ b/lib/serega/validations/attribute/check_opt_delegate.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:delegate` option validator
       #
+      # @private
       class CheckOptDelegate
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_hash_access.rb
+++ b/lib/serega/validations/attribute/check_opt_hash_access.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:hash_access` option validator
       #
+      # @private
       class CheckOptHashAccess
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_hide.rb
+++ b/lib/serega/validations/attribute/check_opt_hide.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:hide` option validator
       #
+      # @private
       class CheckOptHide
         #
         # Checks attribute :hide option

--- a/lib/serega/validations/attribute/check_opt_many.rb
+++ b/lib/serega/validations/attribute/check_opt_many.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:many` option validator
       #
+      # @private
       class CheckOptMany
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_method.rb
+++ b/lib/serega/validations/attribute/check_opt_method.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:method` option validator
       #
+      # @private
       class CheckOptMethod
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_preload.rb
+++ b/lib/serega/validations/attribute/check_opt_preload.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Validator for attribute :preload option
       #
+      # @private
       class CheckOptPreload
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_serializer.rb
+++ b/lib/serega/validations/attribute/check_opt_serializer.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:serializer` option validator
       #
+      # @private
       class CheckOptSerializer
         class << self
           #

--- a/lib/serega/validations/attribute/check_opt_value.rb
+++ b/lib/serega/validations/attribute/check_opt_value.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Attribute
       #
       # Attribute `:value` option validator
       #
+      # @private
       class CheckOptValue
         class << self
           #

--- a/lib/serega/validations/check_attribute_params.rb
+++ b/lib/serega/validations/check_attribute_params.rb
@@ -4,14 +4,17 @@ class Serega
   #
   # Validations
   #
+  # @private
   module SeregaValidations
     #
     # Validations for attribute params
     #
+    # @private
     class CheckAttributeParams
       #
       # Validations for attribute params instance methods
       #
+      # @private
       module InstanceMethods
         # @return [Symbol] validated attribute name
         attr_reader :name

--- a/lib/serega/validations/check_batch_loader_params.rb
+++ b/lib/serega/validations/check_batch_loader_params.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Batch loader parameters validators
     #
+    # @private
     class CheckBatchLoaderParams
       #
       # batch_loader parameters validation instance methods
       #
+      # @private
       module InstanceMethods
         # @return [Symbol] validated batch_loader name
         attr_reader :name

--- a/lib/serega/validations/check_initiate_params.rb
+++ b/lib/serega/validations/check_initiate_params.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Validations of serializer initialization options
     #
+    # @private
     class CheckInitiateParams
       #
       # Validations of serializer initialization options instance methods
       #
+      # @private
       module InstanceMethods
         # @return [Hash] validated initialization options
         attr_reader :opts

--- a/lib/serega/validations/check_serialize_params.rb
+++ b/lib/serega/validations/check_serialize_params.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Validations of serialization options
     #
+    # @private
     class CheckSerializeParams
       #
       # Validations of serialization options instance methods
       #
+      # @private
       module InstanceMethods
         attr_reader :opts
 

--- a/lib/serega/validations/initiate/check_modifiers.rb
+++ b/lib/serega/validations/initiate/check_modifiers.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Validations that take place when initializing serializer
     #
+    # @private
     module Initiate
       #
       # Modifiers validation
       #
+      # @private
       class CheckModifiers
         #
         # Validates provided fields names are existing attributes

--- a/lib/serega/validations/utils/check_allowed_keys.rb
+++ b/lib/serega/validations/utils/check_allowed_keys.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
     #
     # Validations Utilities
     #
+    # @private
     module Utils
       #
       # Utility to check all hash keys are allowed
       #
+      # @private
       class CheckAllowedKeys
         # Checks hash keys are allowed
         #

--- a/lib/serega/validations/utils/check_opt_is_bool.rb
+++ b/lib/serega/validations/utils/check_opt_is_bool.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Utils
       #
       # Utility to check hash key value is boolean
       #
+      # @private
       class CheckOptIsBool
         # Checks hash key has boolean value
         #

--- a/lib/serega/validations/utils/check_opt_is_hash.rb
+++ b/lib/serega/validations/utils/check_opt_is_hash.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Utils
       #
       # Utility to check hash key value is Hash
       #
+      # @private
       class CheckOptIsHash
         # Checks hash key value is Hash
         #

--- a/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
+++ b/lib/serega/validations/utils/check_opt_is_string_or_symbol.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Serega
+  # @private
   module SeregaValidations
+    # @private
     module Utils
       #
       # Utility to check hash key value is String or Symbol
       #
+      # @private
       class CheckOptIsStringOrSymbol
         # Checks hash key has String or Symbol value
         #


### PR DESCRIPTION
Mark all internal machinery (attribute resolution, the serialization engine, plans, validations, utils) and plugin lifecycle callbacks (plugin_name, before/after/load_plugin) @private, and exclude them via --no-private in .yardopts. Generated docs now only show Serega, SeregaConfig, SeregaError and its subclasses, and each plugin's own module plus the config/class methods it adds.

Also fixes real bugs found while reviewing the plugin overview comments and their matching README sections: an undefined variable and a missing comma in the formatters example, a config.root_many= typo, nonexistent auto_preload_attributes_with_* config options, a wrong preload name, and a presenter example that silently dropped its opening/closing lines from the rendered code block. Tightens redundant or unclear wording throughout.